### PR TITLE
Build different NGSI queries depending if the attr is relationship or…

### DIFF
--- a/common/src/main/java/org/fiware/tmforum/common/querying/QueryParser.java
+++ b/common/src/main/java/org/fiware/tmforum/common/querying/QueryParser.java
@@ -3,6 +3,9 @@ package org.fiware.tmforum.common.querying;
 import io.github.wistefan.mapping.JavaObjectMapper;
 import io.github.wistefan.mapping.NgsiLdAttribute;
 import io.github.wistefan.mapping.QueryAttributeType;
+import io.github.wistefan.mapping.annotations.AttributeGetter;
+import io.github.wistefan.mapping.annotations.AttributeType;
+
 import org.fiware.tmforum.common.exception.QueryException;
 
 import java.util.ArrayList;
@@ -12,6 +15,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static io.github.wistefan.mapping.JavaObjectMapper.getGetterMethodByName;
 
 import static org.fiware.tmforum.common.querying.Operator.GREATER_THAN;
 import static org.fiware.tmforum.common.querying.Operator.GREATER_THAN_EQUALS;
@@ -102,11 +107,8 @@ public class QueryParser {
 					NgsiLdAttribute attribute = JavaObjectMapper.getNGSIAttributePath(
 							Arrays.asList(qp.attribute().split("\\.")),
 							queryClass);
-					return new QueryPart(
-							String.join(".", attribute.path()
-							),
-							qp.operator(),
-							encodeValue(qp.value(), attribute.type()));
+
+					return getQueryPart(attribute, qp, isRelationship(queryClass, attribute));
 				})
 				.map(QueryParser::toQueryString);
 
@@ -114,6 +116,46 @@ public class QueryParser {
 			case AND -> queryStrings.collect(Collectors.joining(NGSI_LD_AND));
 			case OR -> queryStrings.collect(Collectors.joining(NGSI_LD_OR));
 		};
+	}
+
+	private static boolean isRelationship(Class<?> queryClass, NgsiLdAttribute attribute) {
+		Optional<AttributeGetter> getter = getGetterMethodByName(queryClass, attribute.path().get(0))
+			.map(m -> {
+				return Arrays.stream(m.getAnnotations())
+					.filter(AttributeGetter.class::isInstance)
+					.map(AttributeGetter.class::cast)
+					.findFirst();
+			})
+			.filter(a -> a.isPresent())
+			.map(a -> a.get())
+			.findFirst();
+
+		return getter.isPresent() &&
+			(getter.get().value().equals(AttributeType.RELATIONSHIP) ||
+			getter.get().value().equals(AttributeType.RELATIONSHIP_LIST));
+	}
+
+	private static QueryPart getQueryPart(NgsiLdAttribute attribute, QueryPart qp, boolean isRel) {
+		// The query part will depend on the type of query
+		// if the query is to a relationship subproperties will be joined with .
+		// if the query is to a property with structured values the path will be
+		// added between brackets
+
+		String attrPath;
+		if (isRel) {
+			attrPath = String.join(".", attribute.path());
+		} else {
+			String first = attribute.path().remove(0);
+			attrPath = first + String.join("", attribute.path()
+				.stream()
+				.map(a -> "[" + a + "]")
+				.toList());
+		}
+
+		return new QueryPart(
+				attrPath,
+				qp.operator(),
+				encodeValue(qp.value(), attribute.type()));
 	}
 
 	private static String encodeValue(String value, QueryAttributeType type) {

--- a/common/src/main/java/org/fiware/tmforum/common/querying/QueryParser.java
+++ b/common/src/main/java/org/fiware/tmforum/common/querying/QueryParser.java
@@ -10,6 +10,7 @@ import org.fiware.tmforum.common.exception.QueryException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,7 +52,9 @@ public class QueryParser {
 	}
 
 	private static String removeWellKnownParameters(String queryString) {
-		List<String> parameters = Arrays.asList(queryString.split(TMFORUM_AND));
+		// Using linked list as the list returned by asList method is fixed-size
+		// so the remove method raises a non implemented exception
+		List<String> parameters = new LinkedList<>(Arrays.asList(queryString.split(TMFORUM_AND)));
 		List<String> wellKnownParams = parameters
 				.stream()
 				.filter(p -> p.startsWith(LIMIT_KEY)

--- a/common/src/test/java/org/fiware/tmforum/common/querying/MyPojo.java
+++ b/common/src/test/java/org/fiware/tmforum/common/querying/MyPojo.java
@@ -21,6 +21,8 @@ public class MyPojo {
 	private SubObject sub;
 	private SubObject otherNamedSub;
 	private Integer temperature;
+	private RelObject rel;
+	private List<RelObject> relList;
 
 	// required constructor
 	public MyPojo(String id) {
@@ -85,5 +87,25 @@ public class MyPojo {
 	@AttributeSetter(value = AttributeType.PROPERTY, targetName = "otherSub", targetClass = SubObject.class)
 	public void setOtherNamedSub(SubObject otherSub) {
 		this.otherNamedSub = otherNamedSub;
+	}
+
+	@AttributeGetter(value = AttributeType.RELATIONSHIP, targetName = "rel")
+	public RelObject getRel() {
+		return rel;
+	}
+
+	@AttributeSetter(value = AttributeType.RELATIONSHIP, targetName = "rel", targetClass = RelObject.class)
+	public void setRel(RelObject rel) {
+		this.rel = rel;
+	}
+
+	@AttributeGetter(value = AttributeType.RELATIONSHIP_LIST, targetName = "relList")
+	public List<RelObject> getRelList() {
+		return relList;
+	}
+
+	@AttributeSetter(value = AttributeType.RELATIONSHIP_LIST, targetName = "relList", targetClass = RelObject.class)
+	public void setRelList(List<RelObject> rel) {
+		this.relList = relList;
 	}
 }

--- a/common/src/test/java/org/fiware/tmforum/common/querying/QueryParserTest.java
+++ b/common/src/test/java/org/fiware/tmforum/common/querying/QueryParserTest.java
@@ -19,15 +19,16 @@ class QueryParserTest {
 
 	private static Stream<Arguments> queries() {
 		return Stream.of(
+				// Property attributes queries
 				Arguments.of("status=Active,Started&color=Red", "status==(\"Active\"|\"Started\");color==\"Red\"", MyPojo.class),
 				Arguments.of("status=Active,Started;color=Red", "color==\"Red\"|status==(\"Active\"|\"Started\")", MyPojo.class),
 				Arguments.of("status=Active;status=Started", "status==(\"Active\"|\"Started\")", MyPojo.class),
 				Arguments.of("status=Active;status=Started;color=Red", "color==\"Red\"|status==(\"Active\"|\"Started\")",
 						MyPojo.class),
 				Arguments.of("sub.status=Active;status=Started;color=Red",
-						"color==\"Red\"|sub.status==\"Active\"|status==\"Started\"", MyPojo.class),
+						"color==\"Red\"|sub[status]==\"Active\"|status==\"Started\"", MyPojo.class),
 				Arguments.of("sub.status=Active;otherNamedSub.status=Started;color=Red",
-						"color==\"Red\"|otherSub.status==\"Started\"|sub.status==\"Active\"", MyPojo.class),
+						"color==\"Red\"|otherSub[status]==\"Started\"|sub[status]==\"Active\"", MyPojo.class),
 				Arguments.of("temperature<20&temperature>10", "temperature<20;temperature>10", MyPojo.class),
 				Arguments.of("temperature<=20;temperature=30", "temperature==30|temperature<=20", MyPojo.class),
 				Arguments.of("temperature>=20;temperature<3", "temperature<3|temperature>=20", MyPojo.class),
@@ -39,13 +40,16 @@ class QueryParserTest {
 				Arguments.of("status.eq=Active;status.eq=Started;color.eq=Red", "color==\"Red\"|status==(\"Active\"|\"Started\")",
 						MyPojo.class),
 				Arguments.of("sub.status.eq=Active;status.eq=Started;color.eq=Red",
-						"color==\"Red\"|sub.status==\"Active\"|status==\"Started\"", MyPojo.class),
+						"color==\"Red\"|sub[status]==\"Active\"|status==\"Started\"", MyPojo.class),
 				Arguments.of("sub.status.eq=Active;otherNamedSub.status.eq=Started;color.eq=Red",
-						"color==\"Red\"|otherSub.status==\"Started\"|sub.status==\"Active\"", MyPojo.class),
+						"color==\"Red\"|otherSub[status]==\"Started\"|sub[status]==\"Active\"", MyPojo.class),
 				Arguments.of("temperature.lt=20&temperature.gt=10", "temperature<20;temperature>10", MyPojo.class),
 				Arguments.of("temperature.lte=20;temperature.eq=30", "temperature==30|temperature<=20", MyPojo.class),
-				Arguments.of("temperature.gte=20;temperature.lt=3", "temperature<3|temperature>=20", MyPojo.class)
+				Arguments.of("temperature.gte=20;temperature.lt=3", "temperature<3|temperature>=20", MyPojo.class),
 
+				// Relationship attributes queries
+				Arguments.of("rel.name=therel", "rel.name==\"therel\"", MyPojo.class),
+				Arguments.of("relList.name=therel", "relList.name==\"therel\"", MyPojo.class)
 		);
 	}
 }

--- a/common/src/test/java/org/fiware/tmforum/common/querying/RelObject.java
+++ b/common/src/test/java/org/fiware/tmforum/common/querying/RelObject.java
@@ -1,0 +1,8 @@
+package org.fiware.tmforum.common.querying;
+
+import lombok.Data;
+
+@Data
+public class RelObject {
+    private String name;
+}


### PR DESCRIPTION
Current implementation of the QueryParser asumes that all the queries search for metadata, which is only true for Relationship attributes

This query:

`http://localhost:8632/individual?relatedParty.href=1234`

Should be translated to this NGSI query

`http://localhost:1026/ngsi-ld/v1/entities/?type=individual&q=relatedParty.hef=="1234"`

But, embedded attributes in TMForum are stored as structured properties, so the query to the context broker should be done adding brakets.

This query

`http://localhost:8632/individual?externalReference.name=1234`

Should be translated to this one:

`http://localhost:1026/ngsi-ld/v1/entities/?type=individual&q=externalReference[name]=="1234"`

This PR builds one query or the other depending on the attribute type.


