### PR TITLE
Account management api implementation

### DIFF
--- a/account/src/main/java/org/fiware/tmforum/account/domain/Account.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/Account.java
@@ -49,15 +49,15 @@ public abstract class Account extends EntityWithId {
     private String state;
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "accountBalance") }))
-    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "accountBalance") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "accountBalance", targetClass = AccountBalance.class) }))
     private List<AccountBalance> accountBalance;
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "accountRelationship") }))
-    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "accountRelationship") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "accountRelationship", targetClass = AccountRelationship.class) }))
     private List<AccountRelationship> accountRelationship;
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "contact") }))
-    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "contact") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "contact", targetClass = Contact.class) }))
     private List<Contact> contact;
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "creditLimit") }))
@@ -70,7 +70,7 @@ public abstract class Account extends EntityWithId {
     private List<RelatedParty> relatedParty;
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "taxExemption") }))
-    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "taxExemption") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "taxExemption", targetClass = AccountTaxExemption.class) }))
     private List<AccountTaxExemption> taxExemption;
 
     @Override

--- a/account/src/main/java/org/fiware/tmforum/account/domain/BillFormat.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/BillFormat.java
@@ -24,7 +24,7 @@ public class BillFormat extends EntityWithId {
         super(TYPE_BILLF, id);
     }
 
-    public static final String TYPE_BILLF = "billFormat";
+    public static final String TYPE_BILLF = "bill-format";
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "href") }))
     @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY, targetName = "href") }))

--- a/account/src/main/java/org/fiware/tmforum/account/domain/BillPresentationMedia.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/BillPresentationMedia.java
@@ -24,7 +24,7 @@ public class BillPresentationMedia extends EntityWithId {
         super(TYPE_BILLPM, id);
     }
 
-    public static final String TYPE_BILLPM = "billingPresentationMedia";
+    public static final String TYPE_BILLPM = "bill-presentation-media";
 
     @Getter(onMethod = @__({@AttributeGetter(value = AttributeType.PROPERTY, targetName = "href")}))
     @Setter(onMethod = @__({@AttributeSetter(value = AttributeType.PROPERTY, targetName = "href")}))

--- a/account/src/main/java/org/fiware/tmforum/account/domain/BillingAccount.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/BillingAccount.java
@@ -26,7 +26,7 @@ public class BillingAccount extends Account {
         super(TYPE_BILLINGAC, id);
     }
 
-    public static final String TYPE_BILLINGAC = "billingAccount";
+    public static final String TYPE_BILLINGAC = "billing-account";
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))
     @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))

--- a/account/src/main/java/org/fiware/tmforum/account/domain/BillingAccount.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/BillingAccount.java
@@ -45,7 +45,7 @@ public class BillingAccount extends Account {
     private FinancialAccountRef financialAccount;
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan") }))
-    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan", targetClass = PaymentPlan.class) }))
     private List<PaymentPlan> paymentPlan;
 
 

--- a/account/src/main/java/org/fiware/tmforum/account/domain/BillingAccount.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/BillingAccount.java
@@ -12,17 +12,41 @@ import org.fiware.tmforum.common.domain.RelatedParty;
 import org.fiware.tmforum.common.domain.Money;
 import org.fiware.tmforum.common.domain.TimePeriod;
 import org.fiware.tmforum.product.CategoryRef;
+import org.fiware.account.model.PaymentMethodRefVO;
 
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
-@MappingEnabled(entityType = BillingAccount.TYPE_PARTYAC)
-public class BillingAccount extends PartyAccount {
+@MappingEnabled(entityType = BillingAccount.TYPE_BILLINGAC)
+public class BillingAccount extends Account {
 
     public BillingAccount(String id) {
-        super(id);
+        super(TYPE_BILLINGAC, id);
     }
+
+    public static final String TYPE_BILLINGAC = "billingAccount";
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))
+    private String paymentStatus;
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "billStructure") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY, targetName = "billStructure") }))
+    private BillStructure billStructure;
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.RELATIONSHIP, targetName = "defaultPaymentMethod", embedProperty = true) }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.RELATIONSHIP, targetName = "defaultPaymentMethod", targetClass = PaymentMethodRefVO.class, fromProperties = true) }))
+    private PaymentMethodRef defaultPaymentMethod;
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.RELATIONSHIP, targetName = "financialAccount") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.RELATIONSHIP, targetName = "financialAccount", targetClass = FinancialAccountRef.class) }))
+    private FinancialAccountRef financialAccount;
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan") }))
+    private List<PaymentPlan> paymentPlan;
+
 
 }

--- a/account/src/main/java/org/fiware/tmforum/account/domain/PartyAccount.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/PartyAccount.java
@@ -24,7 +24,7 @@ public class PartyAccount extends Account {
         super(TYPE_PARTYAC, id);
     }
 
-    public static final String TYPE_PARTYAC = "partyAccount";
+    public static final String TYPE_PARTYAC = "party-account";
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))
     @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))

--- a/account/src/main/java/org/fiware/tmforum/account/domain/SettlementAccount.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/SettlementAccount.java
@@ -26,7 +26,7 @@ public class SettlementAccount extends Account {
         super(TYPE_SETTLEMENTAC, id);
     }
 
-    public static final String TYPE_SETTLEMENTAC = "settlementAccount";
+    public static final String TYPE_SETTLEMENTAC = "settlement-account";
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))
     @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))

--- a/account/src/main/java/org/fiware/tmforum/account/domain/SettlementAccount.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/SettlementAccount.java
@@ -45,7 +45,7 @@ public class SettlementAccount extends Account {
     private FinancialAccountRef financialAccount;
 
     @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan") }))
-    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan", targetClass = PaymentPlan.class) }))
     private List<PaymentPlan> paymentPlan;
 
 }

--- a/account/src/main/java/org/fiware/tmforum/account/domain/SettlementAccount.java
+++ b/account/src/main/java/org/fiware/tmforum/account/domain/SettlementAccount.java
@@ -12,18 +12,40 @@ import org.fiware.tmforum.common.domain.RelatedParty;
 import org.fiware.tmforum.common.domain.TimePeriod;
 import org.fiware.tmforum.common.domain.Money;
 import org.fiware.tmforum.product.CategoryRef;
+import org.fiware.account.model.PaymentMethodRefVO;
 
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
-@MappingEnabled(entityType = BillingAccount.TYPE_PARTYAC)
-public class SettlementAccount extends PartyAccount {
+@MappingEnabled(entityType = SettlementAccount.TYPE_SETTLEMENTAC)
+public class SettlementAccount extends Account {
 
     public SettlementAccount(String id) {
-        super(id);
+        super(TYPE_SETTLEMENTAC, id);
     }
 
+    public static final String TYPE_SETTLEMENTAC = "settlementAccount";
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY, targetName = "paymentStatus") }))
+    private String paymentStatus;
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY, targetName = "billStructure") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY, targetName = "billStructure") }))
+    private BillStructure billStructure;
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.RELATIONSHIP, targetName = "defaultPaymentMethod", embedProperty = true) }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.RELATIONSHIP, targetName = "defaultPaymentMethod", targetClass = PaymentMethodRefVO.class, fromProperties = true) }))
+    private PaymentMethodRef defaultPaymentMethod;
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.RELATIONSHIP, targetName = "financialAccount") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.RELATIONSHIP, targetName = "financialAccount", targetClass = FinancialAccountRef.class) }))
+    private FinancialAccountRef financialAccount;
+
+    @Getter(onMethod = @__({ @AttributeGetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan") }))
+    @Setter(onMethod = @__({ @AttributeSetter(value = AttributeType.PROPERTY_LIST, targetName = "paymentPlan") }))
+    private List<PaymentPlan> paymentPlan;
 
 }

--- a/account/src/main/java/org/fiware/tmforum/account/rest/BillingAccountApiController.java
+++ b/account/src/main/java/org/fiware/tmforum/account/rest/BillingAccountApiController.java
@@ -42,7 +42,7 @@ public class BillingAccountApiController extends AbstractApiController<BillingAc
     @Override
     public Mono<HttpResponse<BillingAccountVO>> createBillingAccount(BillingAccountCreateVO billingAccountVo) {
         BillingAccount billingAccount = tmForumMapper.map(
-                tmForumMapper.map(billingAccountVo, IdHelper.toNgsiLd(UUID.randomUUID().toString(), BillingAccount.TYPE_PARTYAC)));
+                tmForumMapper.map(billingAccountVo, IdHelper.toNgsiLd(UUID.randomUUID().toString(), BillingAccount.TYPE_BILLINGAC)));
 
         return create(getCheckingMono(billingAccount), BillingAccount.class)
                 .map(tmForumMapper::map)
@@ -68,7 +68,7 @@ public class BillingAccountApiController extends AbstractApiController<BillingAc
     @Override
     public Mono<HttpResponse<List<BillingAccountVO>>> listBillingAccount(@Nullable String fields, @Nullable Integer offset,
                                                                  @Nullable Integer limit) {
-        return list(offset, limit, BillingAccount.TYPE_PARTYAC, BillingAccount.class)
+        return list(offset, limit, BillingAccount.TYPE_BILLINGAC, BillingAccount.class)
                 .map(categoryStream -> categoryStream.map(tmForumMapper::map).toList())
                 .switchIfEmpty(Mono.just(List.of()))
                 .map(HttpResponse::ok);

--- a/account/src/main/java/org/fiware/tmforum/account/rest/EventSubscriptionApiController.java
+++ b/account/src/main/java/org/fiware/tmforum/account/rest/EventSubscriptionApiController.java
@@ -35,12 +35,12 @@ public class EventSubscriptionApiController extends AbstractSubscriptionApiContr
     private final TMForumMapper tmForumMapper;
     private static final Map<String, String> EVENT_GROUP_TO_ENTITY_NAME_MAPPING = Map.ofEntries(
             entry(EVENT_GROUP_BILL_FORMAT, BillFormat.TYPE_BILLF),
-            entry(EVENT_GROUP_BILLING_ACCOUNT, BillingAccount.TYPE_PARTYAC),
+            entry(EVENT_GROUP_BILLING_ACCOUNT, BillingAccount.TYPE_BILLINGAC),
             entry(EVENT_GROUP_BILLING_CYCLE_SPECIFICATION, BillingCycleSpecification.TYPE_BILLCL),
             entry(EVENT_GROUP_BILL_PRESENTATION_MEDIA, BillPresentationMedia.TYPE_BILLPM),
             entry(EVENT_GROUP_FINANCIAL_ACCOUNT, FinancialAccount.TYPE_FINANCIALAC),
             entry(EVENT_GROUP_PARTY_ACCOUNT, PartyAccount.TYPE_PARTYAC),
-            entry(EVENT_GROUP_SETTLEMENT_ACCOUNT, SettlementAccount.TYPE_PARTYAC)
+            entry(EVENT_GROUP_SETTLEMENT_ACCOUNT, SettlementAccount.TYPE_SETTLEMENTAC)
     );
     private static final List<String> EVENT_GROUPS = List.of(EVENT_GROUP_BILL_FORMAT, /*EVENT_GROUP_BILLING_ACCOUNT,*/
     EVENT_GROUP_BILLING_CYCLE_SPECIFICATION, EVENT_GROUP_BILL_PRESENTATION_MEDIA, EVENT_GROUP_FINANCIAL_ACCOUNT,

--- a/account/src/main/java/org/fiware/tmforum/account/rest/SettlementAccountApiController.java
+++ b/account/src/main/java/org/fiware/tmforum/account/rest/SettlementAccountApiController.java
@@ -42,7 +42,7 @@ public class SettlementAccountApiController extends AbstractApiController<Settle
     @Override
     public Mono<HttpResponse<SettlementAccountVO>> createSettlementAccount(SettlementAccountCreateVO settlementAccountVo) {
         SettlementAccount settlementAccount = tmForumMapper.map(
-                tmForumMapper.map(settlementAccountVo, IdHelper.toNgsiLd(UUID.randomUUID().toString(), SettlementAccount.TYPE_PARTYAC)));
+                tmForumMapper.map(settlementAccountVo, IdHelper.toNgsiLd(UUID.randomUUID().toString(), SettlementAccount.TYPE_SETTLEMENTAC)));
 
         return create(getCheckingMono(settlementAccount), SettlementAccount.class)
                 .map(tmForumMapper::map)
@@ -68,7 +68,7 @@ public class SettlementAccountApiController extends AbstractApiController<Settle
     @Override
     public Mono<HttpResponse<List<SettlementAccountVO>>> listSettlementAccount(@Nullable String fields, @Nullable Integer offset,
                                                                      @Nullable Integer limit) {
-        return list(offset, limit, SettlementAccount.TYPE_PARTYAC, SettlementAccount.class)
+        return list(offset, limit, SettlementAccount.TYPE_SETTLEMENTAC, SettlementAccount.class)
                 .map(settlementAccountStream -> settlementAccountStream.map(tmForumMapper::map).toList())
                 .switchIfEmpty(Mono.just(List.of()))
                 .map(HttpResponse::ok);

--- a/account/src/test/java/org/fiware/tmforum/account/BillingAccountApiIT.java
+++ b/account/src/test/java/org/fiware/tmforum/account/BillingAccountApiIT.java
@@ -54,7 +54,7 @@ public class BillingAccountApiIT extends AbstractApiIT implements BillingAccount
 
     @Override
     protected String getEntityType() {
-        return BillingAccount.TYPE_PARTYAC;
+        return BillingAccount.TYPE_BILLINGAC;
     }
 
     @MockBean(EventHandler.class)

--- a/account/src/test/java/org/fiware/tmforum/account/SettlementAccountApiIT.java
+++ b/account/src/test/java/org/fiware/tmforum/account/SettlementAccountApiIT.java
@@ -54,7 +54,7 @@ public class SettlementAccountApiIT extends AbstractApiIT implements SettlementA
 
     @Override
     protected String getEntityType() {
-        return SettlementAccount.TYPE_PARTYAC;
+        return SettlementAccount.TYPE_SETTLEMENTAC;
     }
 
     @MockBean(EventHandler.class)


### PR DESCRIPTION
Changes to classes Account, BillingAccount and SettlementAccount. There were 2 problems with them. Contact could not map contacMedium, solved, and the way SettlementAccount and BillingAccount were implemented when the call to the BD was made they data was saved with the entityType of PartyAccount, now each one of them has its own.