### PR TITLE
Add 'lastUpdate' field to Catalog (Ticket #831374)

### DIFF
--- a/product-catalog/src/main/java/org/fiware/tmforum/productcatalog/rest/CatalogApiController.java
+++ b/product-catalog/src/main/java/org/fiware/tmforum/productcatalog/rest/CatalogApiController.java
@@ -20,6 +20,7 @@ import org.fiware.tmforum.productcatalog.TMForumMapper;
 import org.fiware.tmforum.productcatalog.domain.Catalog;
 import reactor.core.publisher.Mono;
 
+import java.time.Clock;
 import javax.annotation.Nullable;
 import java.util.*;
 
@@ -28,11 +29,13 @@ import java.util.*;
 public class CatalogApiController extends AbstractApiController<Catalog> implements CatalogApi {
 
     private final TMForumMapper tmForumMapper;
+    private final Clock clock;
 
     public CatalogApiController(QueryParser queryParser, ReferenceValidationService validationService,
-                                TmForumRepository productCatalogRepository, TMForumMapper tmForumMapper, TMForumEventHandler eventHandler) {
+                                TmForumRepository productCatalogRepository, TMForumMapper tmForumMapper, Clock clock, TMForumEventHandler eventHandler) {
         super(queryParser, validationService, productCatalogRepository, eventHandler);
         this.tmForumMapper = tmForumMapper;
+        this.clock = clock;
     }
 
     @Override
@@ -45,6 +48,8 @@ public class CatalogApiController extends AbstractApiController<Catalog> impleme
 
         Catalog catalog = tmForumMapper.map(
                 tmForumMapper.map(catalogVo, IdHelper.toNgsiLd(UUID.randomUUID().toString(), Catalog.TYPE_CATALOG)));
+
+        catalog.setLastUpdate(clock.instant());
 
         return create(getCheckingMono(catalog), Catalog.class)
                 .map(tmForumMapper::map)


### PR DESCRIPTION
As requested in ticket #831374 for DOME, the 'lastUpdate' attribute has been added to the Catalog entity.

Note:
- 'Category' and 'ProductOffering' already had this attribute, so no changes were needed there.
- Unit tests have been executed and passed successfully.

Let us know if any adjustments are needed.