### PR TITLE
fix(aio): handle duplicate keys in CompositeEventMapper to prevent IllegalStateException

### DIFF
--- a/all-in-one/src/main/java/org/fiware/tmforum/mapper/CompositeEventMapper.java
+++ b/all-in-one/src/main/java/org/fiware/tmforum/mapper/CompositeEventMapper.java
@@ -24,7 +24,15 @@ public class CompositeEventMapper implements EventMapper {
 	public Map<String, EventMapping> getEntityClassMapping() {
 		return moduleEventMappers.stream()
 				.flatMap(m -> m.getEntityClassMapping().entrySet().stream())
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+						(existing, duplicate) -> {
+							if (existing.rawClass().equals(duplicate.rawClass())) {
+								return existing;
+							}
+							throw new IllegalStateException(String.format(
+									"Conflicting EventMapping: existing maps to %s, duplicate maps to %s",
+									existing.rawClass().getName(), duplicate.rawClass().getName()));
+						}));
 	}
 
 	@Override


### PR DESCRIPTION
SoftwareManagementEventMapper registers entity type keys already present in ResourceInventoryEventMapper and ResourceCatalogEventMapper, causing Collectors.toMap to throw on duplicate keys in the all-in-one deployment. Add a validating merge function that accepts duplicates with matching rawClass and rejects conflicting ones.