### PR TITLE
fix(resource-order): round-trip entityType and owner on externalReference

### DIFF
--- a/resource-order-management/src/main/java/org/fiware/tmforum/resourceordering/domain/ExternalReference.java
+++ b/resource-order-management/src/main/java/org/fiware/tmforum/resourceordering/domain/ExternalReference.java
@@ -4,16 +4,20 @@ import lombok.Data;
 
 import java.net.URI;
 
-/**
- * External reference of the individual or reference in another system.
- */
 @Data
 public class ExternalReference {
 
-	private URI href;
 	private String id;
+
+	// TMF652 ExternalId fields (current public API shape).
+	private String entityType;
+	private String owner;
+
+	// Legacy ExternalReference fields retained so entities persisted before the TMF652 ExternalId migration remain readable.
+	private URI href;
 	private String externalReferenceType;
 	private String name;
+
 	private String atBaseType;
 	private URI atSchemaLocation;
 	private String atType;


### PR DESCRIPTION
fix(resource-order): round-trip entityType and owner on externalReference

The domain class carried the legacy ExternalReference shape while the
generated VO follows TMF652 ExternalId. MapStruct matches by name, so
entityType and owner were silently dropped on POST and returned null on
GET — only id round-tripped.

Add entityType and owner to the domain class, and keep href,
externalReferenceType and name so any entities persisted before the
migration remain readable. No API contract change: the public shape is
defined by the OpenAPI spec and was already ExternalId; this aligns the
persistence layer with it.

service-order-management is intentionally left untouched because TMF641
still models externalReference with the legacy shape.