### PR TITLE
feat(pagination): total count, Link headers, exact sort/pagination against NGSI-L

### DIFF
--- a/account/src/main/resources/application-orion-ld.yaml
+++ b/account/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/account/src/main/resources/application-orion-ld.yaml
+++ b/account/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/account/src/main/resources/application-scorpio.yaml
+++ b/account/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/account/src/main/resources/application.yaml
+++ b/account/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 
 api:
   account:

--- a/account/src/test/resources/application-orion-ld.yaml
+++ b/account/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/account/src/test/resources/application-orion-ld.yaml
+++ b/account/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/account/src/test/resources/application-scorpio.yaml
+++ b/account/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count

--- a/agreement/src/main/resources/application-orion-ld.yaml
+++ b/agreement/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/agreement/src/main/resources/application-orion-ld.yaml
+++ b/agreement/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/agreement/src/main/resources/application-scorpio.yaml
+++ b/agreement/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/agreement/src/main/resources/application.yaml
+++ b/agreement/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   agreement:
     basepath: ${general.basepath:/}

--- a/agreement/src/test/java/org/fiware/tmforum/agreement/AgreementApiIT.java
+++ b/agreement/src/test/java/org/fiware/tmforum/agreement/AgreementApiIT.java
@@ -278,8 +278,8 @@ public class AgreementApiIT extends AbstractApiIT implements AgreementApiTestSpe
 		Integer limit = 5;
 		listResponse = callAndCatch(
 				() -> agApiTestClient.listAgreement(null, null, null, limit));
-		assertEquals(HttpStatus.OK, listResponse.getStatus(),
-				"Agreement list should be accessible");
+		assertEquals(HttpStatus.PARTIAL_CONTENT, listResponse.getStatus(),
+				"A page that doesn't contain the full result set must be reported as 206, per TMF630.");
 		assertEquals(limit, listResponse.body().size(),
 				"The number of agreements should be the same");
 	}

--- a/agreement/src/test/java/org/fiware/tmforum/agreement/AgreementSpecificationApiIT.java
+++ b/agreement/src/test/java/org/fiware/tmforum/agreement/AgreementSpecificationApiIT.java
@@ -305,8 +305,8 @@ public class AgreementSpecificationApiIT extends AbstractApiIT implements Agreem
 		Integer limit = 5;
 		listResponse = callAndCatch(
 				() -> agSpecApiTestClient.listAgreementSpecification(null, null, null, limit));
-		assertEquals(HttpStatus.OK, listResponse.getStatus(),
-				"Agreement specification list should be accessible");
+		assertEquals(HttpStatus.PARTIAL_CONTENT, listResponse.getStatus(),
+				"A page that doesn't contain the full result set must be reported as 206, per TMF630.");
 		assertEquals(limit, listResponse.body().size(),
 				"The number of agreement specifications should be the same");
 	}

--- a/all-in-one/src/main/resources/application-orion-ld.yaml
+++ b/all-in-one/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/all-in-one/src/main/resources/application-orion-ld.yaml
+++ b/all-in-one/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/all-in-one/src/main/resources/application-scorpio.yaml
+++ b/all-in-one/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/all-in-one/src/main/resources/application.yaml
+++ b/all-in-one/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
   basepath: /
 apiExtension:
   enabled: ${API_EXTENSION_ENABLED}

--- a/common/src/main/java/org/fiware/tmforum/common/configuration/GeneralProperties.java
+++ b/common/src/main/java/org/fiware/tmforum/common/configuration/GeneralProperties.java
@@ -68,4 +68,12 @@ public class GeneralProperties {
 	 * Required for Scorpio 6.x which appends to array attributes on PATCH. Default false (Orion-LD).
 	 */
 	private boolean replaceOnUpdate = false;
+
+	/**
+	 * Name of the response header the target NGSI-LD broker uses to report the total number of
+	 * entities matching a query (e.g. "NGSILD-Results-Count" for Scorpio, "Fiware-Total-Count" for
+	 * Orion-LD). Null if not configured for the active broker profile - in that case, pagination
+	 * degrades gracefully (no X-Total-Count, no exact next/last, status always 200).
+	 */
+	private String countHeader = null;
 }

--- a/common/src/main/java/org/fiware/tmforum/common/configuration/GeneralProperties.java
+++ b/common/src/main/java/org/fiware/tmforum/common/configuration/GeneralProperties.java
@@ -71,9 +71,10 @@ public class GeneralProperties {
 
 	/**
 	 * Name of the response header the target NGSI-LD broker uses to report the total number of
-	 * entities matching a query (e.g. "NGSILD-Results-Count" for Scorpio, "Fiware-Total-Count" for
-	 * Orion-LD). Null if not configured for the active broker profile - in that case, pagination
-	 * degrades gracefully (no X-Total-Count, no exact next/last, status always 200).
+	 * entities matching a query. Defaults to the header name defined by the NGSI-LD standard; brokers
+	 * that deviate from the standard can override this property per profile. Set to null/empty to
+	 * disable count reporting - in that case, pagination degrades gracefully (no X-Total-Count, no
+	 * exact next/last, status always 200).
 	 */
-	private String countHeader = null;
+	private String countHeader = "NGSILD-Results-Count";
 }

--- a/common/src/main/java/org/fiware/tmforum/common/filter/ForwardHeaderParser.java
+++ b/common/src/main/java/org/fiware/tmforum/common/filter/ForwardHeaderParser.java
@@ -1,0 +1,160 @@
+package org.fiware.tmforum.common.filter;
+
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.server.HttpServerConfiguration;
+import io.micronaut.http.ssl.ServerSslConfiguration;
+import jakarta.inject.Singleton;
+
+import java.util.function.Consumer;
+
+/**
+ * Parses HTTP forwarding headers to extract client request information.
+ *
+ * <p>
+ * This parser handles both the standard RFC 7239 `Forwarded` header and
+ * configurable legacy `X-Forwarded-*` headers. It extracts key information
+ * such as:
+ * <ul>
+ *     <li>Original client IP address (`for` / X-Forwarded-For)</li>
+ *     <li>Original protocol (`proto` / X-Forwarded-Proto)</li>
+ *     <li>Host and optional port (`host` / X-Forwarded-Host and X-Forwarded-Port)</li>
+ *     <li>Proxy information (`by`)</li>
+ *     <li>Path prefix added by upstream proxies (`X-Forwarded-Prefix`)</li>
+ * </ul>
+ * </p>
+ */
+@Singleton
+public class ForwardHeaderParser {
+
+	public static final int DEFAULT_HTTP_PORT = 80;
+	public static final int DEFAULT_HTTPS_PORT = 443;
+
+	private static final String DEFAULT_HOST = "localhost";
+	private static final String HTTP_PROTOCOL = "http";
+	private static final String HTTPS_PROTOCOL = "https";
+
+	// RFC 7239 directive names
+	private static final String FOR_DIRECTIVE = "for";
+	private static final String HOST_DIRECTIVE = "host";
+	private static final String PROTO_DIRECTIVE = "proto";
+	private static final String BY_DIRECTIVE = "by";
+
+	private final ForwardedForConfig config;
+	private final int serverPort;
+	private final String defaultServerProtocol;
+	private final String defaultHost;
+
+	public ForwardHeaderParser(ForwardedForConfig config, HttpServerConfiguration serverConfiguration,
+							   ServerSslConfiguration sslConfig) {
+
+		this.config = config;
+		this.serverPort = serverConfiguration.getPort().orElse(HttpServerConfiguration.DEFAULT_PORT);
+		this.defaultServerProtocol = sslConfig.isEnabled() ? HTTPS_PROTOCOL : HTTP_PROTOCOL;
+		this.defaultHost = serverConfiguration.getHost().orElse(DEFAULT_HOST);
+	}
+
+	/**
+	 * Parses the provided HTTP headers to extract forwarding information.
+	 *
+	 * <p>
+	 * This method reads both the standard `Forwarded` header (RFC 7239) and
+	 * any legacy `X-Forwarded-*` headers as configured in {@link ForwardedForConfig}.
+	 * It populates a {@link ForwardedInfo} object with the extracted details:
+	 * client IP (`for`), protocol (`proto`), host, port, proxy (`by`), and path prefix.
+	 * `Forwarded` header values take precedence over legacy headers when both are present.
+	 * </p>
+	 *
+	 * <p>
+	 * The returned {@link ForwardedInfo} object can be used by downstream filters or
+	 * controllers to reconstruct the original request URL or handle redirects correctly
+	 * when behind reverse proxies.
+	 * </p>
+	 *
+	 * @param request the incoming request
+	 * @return a {@link ForwardedInfo} object containing the parsed forwarding details
+	 */
+	public ForwardedInfo parse(HttpRequest<?> request) {
+
+		HttpHeaders headers = request.getHeaders();
+		ForwardedInfo forwardedInfo = new ForwardedInfo(null, defaultServerProtocol, defaultHost, serverPort, null, "");
+		parseLegacyForwardedHeaders(headers, forwardedInfo);
+		parseForwardedHeader(headers, forwardedInfo);
+
+		int port = forwardedInfo.getForwardedPort();
+		String proto = forwardedInfo.getForwardedProto();
+
+		if (port == 0) {
+			forwardedInfo.setForwardedPort(HTTPS_PROTOCOL.equalsIgnoreCase(proto) ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT);
+		} else if (port == -1) {
+			// Use the actual server port if the forwarded port is invalid
+			forwardedInfo.setForwardedPort(request.getServerAddress().getPort());
+		}
+
+		return forwardedInfo;
+	}
+
+	private void parseForwardedHeader(HttpHeaders headers, ForwardedInfo defaultEntry) {
+
+		String forwardedHeader = headers.get(HttpHeaders.FORWARDED);
+		if (forwardedHeader == null || forwardedHeader.isEmpty()) {
+			return ;
+		}
+
+		String[] directives = forwardedHeader.split(";");
+
+		for (String directive : directives) {
+			// get only first keyValue if multiple are present
+			String[] keyValue = directive.trim().split(",")[0].split("=", 2);
+			if (keyValue.length == 2) {
+				String key = keyValue[0].trim().toLowerCase();
+				String value = keyValue[1].trim().replaceAll("^\"|\"$", ""); // remove quotes
+				switch (key) {
+					case FOR_DIRECTIVE:
+						defaultEntry.setForwardedFor(value);
+						break;
+					case PROTO_DIRECTIVE:
+						defaultEntry.setForwardedProto(value);
+						break;
+					case HOST_DIRECTIVE:
+						// Extract host and optional port
+						if (value.contains(":")) {
+							String[] hostParts = value.split(":", 2);
+							defaultEntry.setForwardedHost(hostParts[0]);
+							try {
+								defaultEntry.setForwardedPort(Integer.parseInt(hostParts[1]));
+							} catch (NumberFormatException e) {
+								defaultEntry.setForwardedPort(0);
+							}
+						} else {
+							defaultEntry.setForwardedHost(value);
+							defaultEntry.setForwardedPort(0);
+						}
+						break;
+					case BY_DIRECTIVE:
+						defaultEntry.setForwardedBy(value);
+						break;
+				}
+			}
+		}
+	}
+
+	private void parseLegacyForwardedHeaders(HttpHeaders headers, ForwardedInfo defaultEntry) {
+
+		getHeaderValue(headers, config.getForHeader(), defaultEntry::setForwardedFor);
+		getHeaderValue(headers, config.getProtocolHeader(), defaultEntry::setForwardedProto);
+		getHeaderValue(headers, config.getHostHeader(), defaultEntry::setForwardedHost);
+		getHeaderValue(headers, config.getPortHeader(), defaultEntry::setForwardedPortStr);
+		getHeaderValue(headers, config.getPrefixHeader(), defaultEntry::setForwardedPrefix);
+	}
+
+	private void getHeaderValue(HttpHeaders headers, String headerName, Consumer<String> setter) {
+
+		if (headerName != null) {
+			String value = headers.get(headerName);
+			if (value != null) {
+				setter.accept(value);
+			}
+		}
+	}
+}

--- a/common/src/main/java/org/fiware/tmforum/common/filter/ForwardedForConfig.java
+++ b/common/src/main/java/org/fiware/tmforum/common/filter/ForwardedForConfig.java
@@ -1,0 +1,76 @@
+package org.fiware.tmforum.common.filter;
+
+import io.micronaut.context.annotation.ConfigurationInject;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
+import lombok.Getter;
+
+/**
+ * Configuration for processing forwarded request headers.
+ * This configuration is used to extract information from headers such as
+ * Forwarded and X-Forwarded-* to determine the original request details.
+ * `Forwarded` header, as defined in RFC 7239, is preferred over `X-Forwarded-*` headers.
+ *
+ * <p>
+ * Unlike a single-deployment application, this connector ships as 18 independently deployed
+ * modules, each with its own {@code application.yaml}. Requiring every module to configure these
+ * header names explicitly would be needless duplication, so each defaults to the standard
+ * de-facto header name and only needs {@code micronaut.server.forward-headers.*} set if a
+ * specific deployment uses non-standard header names.
+ * </p>
+ */
+@ConfigurationProperties("micronaut.server.forward-headers")
+@Getter
+public class ForwardedForConfig {
+
+	private static final String DEFAULT_PROTOCOL_HEADER = "X-Forwarded-Proto";
+	private static final String DEFAULT_PORT_HEADER = "X-Forwarded-Port";
+	private static final String DEFAULT_HOST_HEADER = "X-Forwarded-Host";
+	private static final String DEFAULT_PREFIX_HEADER = "X-Forwarded-Prefix";
+	private static final String DEFAULT_FOR_HEADER = "X-Forwarded-For";
+
+	/**
+	 * The name of the header that carries the protocol.
+	 * Default: "X-Forwarded-Proto".
+	 */
+	private String protocolHeader;
+
+	/**
+	 * The name of the header that carries the port.
+	 * Default: "X-Forwarded-Port".
+	 */
+	private String portHeader;
+
+	/**
+	 * The name of the header that carries the host.
+	 * Default: "X-Forwarded-Host".
+	 */
+	private String hostHeader;
+
+	/**
+	 * The name of the header that carries the context path or prefix of the request.
+	 * Default: "X-Forwarded-Prefix".
+	 */
+	private String prefixHeader;
+
+	/**
+	 * The name of the header that carries the client's IP address.
+	 * Default: "X-Forwarded-For".
+	 */
+	private String forHeader;
+
+	@ConfigurationInject
+	public ForwardedForConfig(
+			@Nullable String protocolHeader,
+			@Nullable String portHeader,
+			@Nullable String hostHeader,
+			@Nullable String prefixHeader,
+			@Nullable String forHeader) {
+
+		this.protocolHeader = protocolHeader != null ? protocolHeader : DEFAULT_PROTOCOL_HEADER;
+		this.portHeader = portHeader != null ? portHeader : DEFAULT_PORT_HEADER;
+		this.hostHeader = hostHeader != null ? hostHeader : DEFAULT_HOST_HEADER;
+		this.prefixHeader = prefixHeader != null ? prefixHeader : DEFAULT_PREFIX_HEADER;
+		this.forHeader = forHeader != null ? forHeader : DEFAULT_FOR_HEADER;
+	}
+}

--- a/common/src/main/java/org/fiware/tmforum/common/filter/ForwardedForFilter.java
+++ b/common/src/main/java/org/fiware/tmforum/common/filter/ForwardedForFilter.java
@@ -1,0 +1,99 @@
+package org.fiware.tmforum.common.filter;
+
+import io.micronaut.core.order.Ordered;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import io.micronaut.http.uri.UriBuilder;
+import org.reactivestreams.Publisher;
+
+import java.net.URI;
+
+/**
+ * HTTP server filter that normalizes and exposes forwarding information for incoming requests.
+ *
+ * <p>
+ * This filter reads the RFC 7239 Forwarded header as well as legacy X-Forwarded-* headers
+ * (such as X-Forwarded-For, X-Forwarded-Proto, X-Forwarded-Host, X-Forwarded-Prefix) from
+ * each request. It parses these headers to determine the original client IP, protocol,
+ * host, port, and any path prefix applied by upstream proxies or gateways.
+ * </p>
+ *
+ * <p>
+ * The filter then computes the full original request URL and stores it, along with the parsed
+ * forwarding details, as attributes in the request:
+ * <ul>
+ *     <li>{@link #REQ_ATTR}: the reconstructed request URI</li>
+ *     <li>{@link #FORWARD_INFO_ATTR}: the {@link ForwardedInfo} object containing all parsed forwarding information</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * Downstream controllers and filters can use these attributes to correctly generate
+ * absolute URLs, redirects, or logs that reflect the original client-facing request
+ * even when behind reverse proxies (e.g. {@link PaginationFilter} uses {@link #REQ_ATTR} to build
+ * absolute pagination links).
+ * </p>
+ */
+@Filter(Filter.MATCH_ALL_PATTERN)
+public class ForwardedForFilter implements HttpServerFilter, Ordered {
+
+	public static final String REQ_ATTR = "server-req";
+	public static final String FORWARD_INFO_ATTR = "forwarded-info";
+
+	private static final String HTTP_PROTOCOL = "http";
+	private static final String HTTPS_PROTOCOL = "https";
+
+	private final ForwardHeaderParser forwardHeaderParser;
+
+	public ForwardedForFilter(ForwardHeaderParser forwardHeaderParser) {
+
+		this.forwardHeaderParser = forwardHeaderParser;
+	}
+
+	@Override
+	public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+
+		ForwardedInfo forwardedInfo = forwardHeaderParser.parse(request);
+
+		URI reqUrl = getReqUrl(forwardedInfo);
+
+		HttpRequest<?> modifiedRequest = request
+				.setAttribute(REQ_ATTR, reqUrl)
+				.setAttribute(FORWARD_INFO_ATTR, forwardedInfo);
+
+		return chain.proceed(modifiedRequest);
+	}
+
+	private URI getReqUrl(ForwardedInfo forwardedInfo) {
+
+
+		String protocol = forwardedInfo.getForwardedProto();
+		String host = forwardedInfo.getForwardedHost();
+		int port = forwardedInfo.getForwardedPort();
+		String prefix = forwardedInfo.getForwardedPrefix();
+
+		// Ignore default ports
+		Integer portToUse = null;
+		if (!(HTTP_PROTOCOL.equalsIgnoreCase(protocol) && port == ForwardHeaderParser.DEFAULT_HTTP_PORT)
+				&& !(HTTPS_PROTOCOL.equalsIgnoreCase(protocol) && port == ForwardHeaderParser.DEFAULT_HTTPS_PORT)) {
+			portToUse = port;
+		}
+
+		UriBuilder builder = UriBuilder.of(protocol + "://" + host).path(prefix);
+
+		if (portToUse != null) {
+			builder.port(portToUse);
+		}
+
+		return builder.build();
+	}
+
+	@Override
+	public int getOrder() {
+
+		return Ordered.HIGHEST_PRECEDENCE;
+	}
+}

--- a/common/src/main/java/org/fiware/tmforum/common/filter/ForwardedInfo.java
+++ b/common/src/main/java/org/fiware/tmforum/common/filter/ForwardedInfo.java
@@ -1,0 +1,29 @@
+package org.fiware.tmforum.common.filter;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+
+@AllArgsConstructor
+@ToString
+@Data
+public class ForwardedInfo {
+
+	private String forwardedFor;
+	private String forwardedProto;
+	private String forwardedHost;
+	private int forwardedPort;
+	private String forwardedBy;
+	private String forwardedPrefix;
+
+	public void setForwardedPortStr(String portStr) {
+		if (portStr == null || portStr.isEmpty()) {
+			return;
+		}
+		this.forwardedPort = Integer.parseInt(portStr);
+	}
+
+	public String getForwardedPrefix() {
+		return forwardedPrefix != null ? forwardedPrefix : "";
+	}
+}

--- a/common/src/main/java/org/fiware/tmforum/common/filter/PaginationFilter.java
+++ b/common/src/main/java/org/fiware/tmforum/common/filter/PaginationFilter.java
@@ -3,6 +3,7 @@ package org.fiware.tmforum.common.filter;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.filter.HttpServerFilter;
@@ -20,7 +21,7 @@ import java.util.Optional;
 
 /**
  * Adds a TMF630-style {@code Link} header (self/first/prev/next) to responses produced by
- * {@link org.fiware.tmforum.common.rest.AbstractApiController#list}, which stashes the resolved
+ * {@code AbstractApiController#list}, which stashes the resolved
  * {@code offset}/{@code limit}/returned-count as request attributes for this filter to read - a
  * request-attribute handoff, not a change to {@code list()}'s return type, so none of the ~44
  * controllers calling it need to change.
@@ -32,11 +33,14 @@ import java.util.Optional;
  * </p>
  *
  * <p>
- * {@code X-Total-Count}, {@code Content-Range}, and the {@code last} link are deferred to a later
- * phase: they require the total number of matching entities, which this connector does not yet
- * expose from the repository layer. Without a total, {@code next} is inferred from whether the
- * page came back full ({@code returnedCount == limit}) - a reasonable heuristic that can produce a
- * false positive exactly on the last page, resolved once the total count lands.
+ * {@code X-Total-Count} and the {@code last} link are only added when
+ * {@link org.fiware.tmforum.common.configuration.GeneralProperties#getCountHeader()} is configured
+ * for the active broker profile and the broker actually sent that header (see
+ * {@link org.fiware.tmforum.common.repository.TmForumRepository#findEntities}). Without a total,
+ * {@code next} is inferred from whether the page came back full ({@code returnedCount == limit}) -
+ * a reasonable heuristic that can produce a false positive exactly on the last page; with a total,
+ * both {@code next} and the response status ({@code 206 Partial Content} vs {@code 200 OK}, per
+ * TMF630) are exact.
  * </p>
  */
 @Filter(Filter.MATCH_ALL_PATTERN)
@@ -45,9 +49,11 @@ public class PaginationFilter implements HttpServerFilter, Ordered {
 	public static final String OFFSET_ATTR = "pagination-offset";
 	public static final String LIMIT_ATTR = "pagination-limit";
 	public static final String RETURNED_COUNT_ATTR = "pagination-returned-count";
+	public static final String TOTAL_COUNT_ATTR = "pagination-total-count";
 
 	private static final String OFFSET_PARAM = "offset";
 	private static final String LIMIT_PARAM = "limit";
+	private static final String TOTAL_COUNT_HEADER = "X-Total-Count";
 
 	@Override
 	public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
@@ -55,7 +61,7 @@ public class PaginationFilter implements HttpServerFilter, Ordered {
 				.doOnNext(response -> addPaginationLink(request, response));
 	}
 
-	private void addPaginationLink(HttpRequest<?> request, MutableHttpResponse<?> response) {
+	void addPaginationLink(HttpRequest<?> request, MutableHttpResponse<?> response) {
 		Optional<Integer> offsetAttr = request.getAttribute(OFFSET_ATTR, Integer.class);
 		Optional<Integer> limitAttr = request.getAttribute(LIMIT_ATTR, Integer.class);
 		Optional<Integer> returnedCountAttr = request.getAttribute(RETURNED_COUNT_ATTR, Integer.class);
@@ -63,25 +69,50 @@ public class PaginationFilter implements HttpServerFilter, Ordered {
 			// not a paginated list endpoint (create/patch/delete/get-by-id never set these) - no-op.
 			return;
 		}
+		int offset = offsetAttr.get();
+		int limit = limitAttr.get();
+		int returnedCount = returnedCountAttr.get();
+		Integer totalCount = request.getAttribute(TOTAL_COUNT_ATTR, Integer.class).orElse(null);
 
 		URI baseUri = (URI) request.getAttribute(ForwardedForFilter.REQ_ATTR).orElse(URI.create(""));
-		List<String> linkEntries = buildLinkEntries(request, baseUri, offsetAttr.get(), limitAttr.get(), returnedCountAttr.get());
+		List<String> linkEntries = buildLinkEntries(request, baseUri, offset, limit, returnedCount, totalCount);
 		response.header(HttpHeaders.LINK, String.join(", ", linkEntries));
+
+		if (totalCount != null) {
+			response.header(TOTAL_COUNT_HEADER, String.valueOf(totalCount));
+			if (isPartial(returnedCount, totalCount)) {
+				response.status(HttpStatus.PARTIAL_CONTENT);
+			}
+		}
 	}
 
 	/**
-	 * Package-private (not private) so it can be unit-tested directly against a plain
-	 * {@link HttpRequest#GET} instance, without needing a running server or filter chain.
+	 * True per TMF630 iff the response is genuinely a subset of the matching entities - only
+	 * decidable once the total is known, otherwise the status always stays 200 OK.
 	 */
-	static List<String> buildLinkEntries(HttpRequest<?> request, URI baseUri, int offset, int limit, int returnedCount) {
+	static boolean isPartial(int returnedCount, Integer totalCount) {
+		return totalCount != null && returnedCount < totalCount;
+	}
+
+	/**
+	 * {@code totalCount} is null when the broker profile has no count header configured, or the
+	 * broker didn't send a parsable value for it - in that case {@code next} falls back to the
+	 * returned-count-equals-limit heuristic and {@code last} is omitted entirely.
+	 */
+	static List<String> buildLinkEntries(HttpRequest<?> request, URI baseUri, int offset, int limit, int returnedCount, Integer totalCount) {
 		List<String> entries = new ArrayList<>();
 		entries.add(buildLink(request, baseUri, offset, limit, "self"));
 		entries.add(buildLink(request, baseUri, 0, limit, "first"));
 		if (offset > 0) {
 			entries.add(buildLink(request, baseUri, Math.max(0, offset - limit), limit, "prev"));
 		}
-		if (returnedCount == limit) {
+		boolean hasNext = totalCount != null ? (offset + limit < totalCount) : (returnedCount == limit);
+		if (hasNext) {
 			entries.add(buildLink(request, baseUri, offset + limit, limit, "next"));
+		}
+		if (totalCount != null) {
+			int lastOffset = totalCount > 0 ? ((totalCount - 1) / limit) * limit : 0;
+			entries.add(buildLink(request, baseUri, lastOffset, limit, "last"));
 		}
 		return entries;
 	}

--- a/common/src/main/java/org/fiware/tmforum/common/filter/PaginationFilter.java
+++ b/common/src/main/java/org/fiware/tmforum/common/filter/PaginationFilter.java
@@ -1,0 +1,113 @@
+package org.fiware.tmforum.common.filter;
+
+import io.micronaut.core.order.Ordered;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import io.micronaut.http.uri.UriBuilder;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Adds a TMF630-style {@code Link} header (self/first/prev/next) to responses produced by
+ * {@link org.fiware.tmforum.common.rest.AbstractApiController#list}, which stashes the resolved
+ * {@code offset}/{@code limit}/returned-count as request attributes for this filter to read - a
+ * request-attribute handoff, not a change to {@code list()}'s return type, so none of the ~44
+ * controllers calling it need to change.
+ *
+ * <p>
+ * Absolute URLs are built from {@link ForwardedForFilter#REQ_ATTR} so links reflect the
+ * client-facing scheme/host/port/prefix when this service sits behind a load balancer, rather
+ * than the internal address this server sees itself as.
+ * </p>
+ *
+ * <p>
+ * {@code X-Total-Count}, {@code Content-Range}, and the {@code last} link are deferred to a later
+ * phase: they require the total number of matching entities, which this connector does not yet
+ * expose from the repository layer. Without a total, {@code next} is inferred from whether the
+ * page came back full ({@code returnedCount == limit}) - a reasonable heuristic that can produce a
+ * false positive exactly on the last page, resolved once the total count lands.
+ * </p>
+ */
+@Filter(Filter.MATCH_ALL_PATTERN)
+public class PaginationFilter implements HttpServerFilter, Ordered {
+
+	public static final String OFFSET_ATTR = "pagination-offset";
+	public static final String LIMIT_ATTR = "pagination-limit";
+	public static final String RETURNED_COUNT_ATTR = "pagination-returned-count";
+
+	private static final String OFFSET_PARAM = "offset";
+	private static final String LIMIT_PARAM = "limit";
+
+	@Override
+	public Publisher<MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+		return Flux.from(chain.proceed(request))
+				.doOnNext(response -> addPaginationLink(request, response));
+	}
+
+	private void addPaginationLink(HttpRequest<?> request, MutableHttpResponse<?> response) {
+		Optional<Integer> offsetAttr = request.getAttribute(OFFSET_ATTR, Integer.class);
+		Optional<Integer> limitAttr = request.getAttribute(LIMIT_ATTR, Integer.class);
+		Optional<Integer> returnedCountAttr = request.getAttribute(RETURNED_COUNT_ATTR, Integer.class);
+		if (offsetAttr.isEmpty() || limitAttr.isEmpty() || returnedCountAttr.isEmpty()) {
+			// not a paginated list endpoint (create/patch/delete/get-by-id never set these) - no-op.
+			return;
+		}
+
+		URI baseUri = (URI) request.getAttribute(ForwardedForFilter.REQ_ATTR).orElse(URI.create(""));
+		List<String> linkEntries = buildLinkEntries(request, baseUri, offsetAttr.get(), limitAttr.get(), returnedCountAttr.get());
+		response.header(HttpHeaders.LINK, String.join(", ", linkEntries));
+	}
+
+	/**
+	 * Package-private (not private) so it can be unit-tested directly against a plain
+	 * {@link HttpRequest#GET} instance, without needing a running server or filter chain.
+	 */
+	static List<String> buildLinkEntries(HttpRequest<?> request, URI baseUri, int offset, int limit, int returnedCount) {
+		List<String> entries = new ArrayList<>();
+		entries.add(buildLink(request, baseUri, offset, limit, "self"));
+		entries.add(buildLink(request, baseUri, 0, limit, "first"));
+		if (offset > 0) {
+			entries.add(buildLink(request, baseUri, Math.max(0, offset - limit), limit, "prev"));
+		}
+		if (returnedCount == limit) {
+			entries.add(buildLink(request, baseUri, offset + limit, limit, "next"));
+		}
+		return entries;
+	}
+
+	/**
+	 * Rebuilds the current request's path and query string against {@code baseUri} (so the link
+	 * reflects the client-facing host behind a load balancer), preserving every query parameter
+	 * except {@code offset}/{@code limit}, which are overridden with the given values.
+	 */
+	private static String buildLink(HttpRequest<?> request, URI baseUri, int offset, int limit, String rel) {
+		Map<String, List<String>> remainingParams = new LinkedHashMap<>(request.getParameters().asMap());
+		remainingParams.remove(OFFSET_PARAM);
+		remainingParams.remove(LIMIT_PARAM);
+
+		UriBuilder builder = UriBuilder.of(baseUri).path(request.getPath());
+		remainingParams.forEach((key, values) -> values.forEach(value -> builder.queryParam(key, value)));
+		builder.queryParam(OFFSET_PARAM, offset);
+		builder.queryParam(LIMIT_PARAM, limit);
+
+		return String.format("<%s>; rel=\"%s\"", builder.build(), rel);
+	}
+
+	@Override
+	public int getOrder() {
+		// Must run after ForwardedForFilter (HIGHEST_PRECEDENCE) has populated REQ_ATTR before
+		// this filter's own request-phase code (the part of doFilter before chain.proceed) runs.
+		return Ordered.LOWEST_PRECEDENCE;
+	}
+}

--- a/common/src/main/java/org/fiware/tmforum/common/notification/TMForumEventHandler.java
+++ b/common/src/main/java/org/fiware/tmforum/common/notification/TMForumEventHandler.java
@@ -15,6 +15,7 @@ import org.fiware.tmforum.common.notification.checkers.tmforum.TmForumEventCheck
 import org.fiware.tmforum.common.querying.QueryParams;
 import org.fiware.tmforum.common.querying.QueryParser;
 import org.fiware.tmforum.common.querying.SubscriptionQueryResolver;
+import org.fiware.tmforum.common.repository.PagedResult;
 import org.fiware.tmforum.common.repository.TmForumRepository;
 import org.fiware.tmforum.common.rest.AbstractSubscriptionApiController;
 import reactor.core.publisher.Mono;
@@ -51,7 +52,7 @@ public class TMForumEventHandler extends EventHandler {
 				TMForumSubscription.class,
 				queryParser.toNgsiLdQuery(TMForumSubscription.class,
 						String.format("entities=%s&eventTypes=%s", eventDetails.entityType(), eventDetails.eventType())).query()
-		);
+		).map(PagedResult::items);
 	}
 
 	private <T> Mono<Void> handle(T entity, EventDetails eventDetails, TmForumEventChecker eventChecker) {

--- a/common/src/main/java/org/fiware/tmforum/common/querying/QueryParser.java
+++ b/common/src/main/java/org/fiware/tmforum/common/querying/QueryParser.java
@@ -78,6 +78,51 @@ public class QueryParser {
     public static final String TMFORUM_OR_KEY = ";";
     public static final String TMFORUM_AND = "&";
 
+    // TMForum marks a sort field as descending by prefixing it with "-", e.g. sort=name,-billDate
+    private static final String SORT_DESCENDING_PREFIX = "-";
+
+    // NGSI-LD's orderBy suffixes a field with ";desc" to sort descending; omitting it means ascending
+    private static final String ORDER_BY_DESCENDING_SUFFIX = ";desc";
+
+    /**
+     * Translates the TMForum {@code sort} query parameter (comma-separated list of properties,
+     * optionally prefixed with "-" for descending, e.g. {@code sort=name,-billDate}) into the
+     * NGSI-LD {@code orderBy} syntax (comma-separated list of "property;direction" pairs, direction
+     * defaulting to ascending when omitted, e.g. {@code orderBy=name,billDate;desc}).
+     *
+     * @param queryClass class used to resolve the sorted attributes to their NGSI-LD path
+     * @param parameters the request's query parameters
+     * @return the NGSI-LD {@code orderBy} value, or {@code null} if no {@code sort} was requested
+     */
+    public String toOrderBy(Class<?> queryClass, Map<String, List<String>> parameters) {
+        List<String> sortValues = parameters.get(SORT_KEY);
+        if (sortValues == null || sortValues.isEmpty()) {
+            return null;
+        }
+        String orderBy = sortValues.stream()
+                .flatMap(value -> Arrays.stream(value.split(TMFORUM_OR_VALUE)))
+                .filter(sortField -> !sortField.isBlank())
+                .map(sortField -> toOrderByPart(queryClass, sortField))
+                .collect(Collectors.joining(TMFORUM_OR_VALUE));
+        return orderBy.isBlank() ? null : orderBy;
+    }
+
+    private String toOrderByPart(Class<?> queryClass, String sortField) {
+        boolean descending = sortField.startsWith(SORT_DESCENDING_PREFIX);
+        String attributeName = descending ? sortField.substring(1) : sortField;
+
+        List<String> path = translateJsonLdReservedTokens(Arrays.asList(attributeName.split("\\.")));
+        NgsiLdAttribute attribute = JavaObjectMapper.getNGSIAttributePath(path, queryClass);
+        List<String> resolvedPath = new ArrayList<>(attribute.path().isEmpty()
+                ? path.stream().map(ReservedWordHandler::escapeReservedWords).toList()
+                : attribute.path());
+
+        String first = resolvedPath.remove(0);
+        String attrPath = first + String.join("", resolvedPath.stream().map(this::mapPathPart).toList());
+
+        return descending ? attrPath + ORDER_BY_DESCENDING_SUFFIX : attrPath;
+    }
+
     public static boolean hasFilter(Map<String, List<String>> values) {
         //remove the "non-filtering" keys
         values.remove(OFFSET_KEY);

--- a/common/src/main/java/org/fiware/tmforum/common/repository/NgsiLdBaseRepository.java
+++ b/common/src/main/java/org/fiware/tmforum/common/repository/NgsiLdBaseRepository.java
@@ -6,6 +6,7 @@ import io.github.wistefan.mapping.annotations.MappingEnabled;
 import io.micronaut.cache.annotation.CacheInvalidate;
 import io.micronaut.cache.annotation.CachePut;
 import io.micronaut.cache.annotation.Cacheable;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import lombok.RequiredArgsConstructor;
@@ -60,7 +61,7 @@ public abstract class NgsiLdBaseRepository {
 	 */
 	@CachePut(value = CommonConstants.ENTITIES_CACHE_NAME, keyGenerator = EntityIdKeyGenerator.class)
 	public Mono<Void> createEntity(EntityVO entityVO, String ngsiLDTenant) {
-		return entitiesApi.createEntity(entityVO, ngsiLDTenant);
+		return entitiesApi.createEntity(entityVO, ngsiLDTenant).then();
 	}
 
 	/**
@@ -71,7 +72,7 @@ public abstract class NgsiLdBaseRepository {
 	 * @return completable with the result
 	 */
 	public Mono<Void> createSubscription(SubscriptionVO subscriptionVO, String ngsiLDTenant) {
-		return subscriptionsApi.createSubscription(subscriptionVO, ngsiLDTenant);
+		return subscriptionsApi.createSubscription(subscriptionVO, ngsiLDTenant).then();
 	}
 
 	/**
@@ -89,6 +90,7 @@ public abstract class NgsiLdBaseRepository {
 	public Mono<SubscriptionVO> retrieveSubscriptionById(URI subscriptionId) {
 		return subscriptionsApi
 				.retrieveSubscriptionById(subscriptionId)
+				.map(HttpResponse::body)
 				.onErrorResume(this::handleClientSubscriptionException);
 	}
 
@@ -101,7 +103,7 @@ public abstract class NgsiLdBaseRepository {
 	 */
 	@CacheInvalidate(value = CommonConstants.ENTITIES_CACHE_NAME, keyGenerator = EntityIdKeyGenerator.class)
 	public Mono<Void> patchEntity(URI entityId, EntityFragmentVO entityFragmentVO) {
-		return entitiesApi.updateEntity(entityId, entityFragmentVO, generalProperties.getTenant(), null);
+		return entitiesApi.updateEntity(entityId, entityFragmentVO, generalProperties.getTenant(), null).then();
 	}
 
 	/**
@@ -210,7 +212,8 @@ public abstract class NgsiLdBaseRepository {
 					throw new DeletionException(String.format("Was not able to delete %s.", id),
 							t,
 							DeletionExceptionReason.UNKNOWN);
-				});
+				})
+				.then();
 	}
 
 	/**
@@ -242,7 +245,8 @@ public abstract class NgsiLdBaseRepository {
 					}
 					throw new DeletionException(String.format("Was not able to delete %s.", subscriptionId),
 							t, DeletionExceptionReason.UNKNOWN);
-				});
+				})
+				.then();
 	}
 
 	/**
@@ -272,6 +276,7 @@ public abstract class NgsiLdBaseRepository {
 	private Mono<EntityVO> asyncRetrieveEntityById(URI entityId, String ngSILDTenant, String attrs, String type, String options, String link) {
 		return entitiesApi
 				.retrieveEntityById(entityId, ngSILDTenant, attrs, type, options, link)
+				.map(HttpResponse::body)
 				.onErrorResume(this::handleClientEntityException);
 	}
 

--- a/common/src/main/java/org/fiware/tmforum/common/repository/NgsiLdBaseRepository.java
+++ b/common/src/main/java/org/fiware/tmforum/common/repository/NgsiLdBaseRepository.java
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -268,6 +269,34 @@ public abstract class NgsiLdBaseRepository {
 				filtered.map(entityVO -> entityVOMapper.fromEntityVO(entityVO, targetClass)).toList(),
 				oList -> Arrays.stream(oList).map(targetClass::cast).toList()
 		);
+	}
+
+	/**
+	 * Helper method for combining a stream of entities of potentially different NGSI-LD types to a
+	 * single mono, mapping each entity to its own target class instead of one fixed class for the
+	 * whole batch. Used for polymorphic list endpoints that query several NGSI-LD types at once
+	 * (see {@link TmForumRepository#findEntitiesPolymorphic}).
+	 *
+	 * @param entityVOStream stream of entities, potentially of different NGSI-LD types
+	 * @param typeToClass    resolves the target class to map an entity to, based on its NGSI-LD type
+	 * @param <T>            common super-type of all resolved target classes
+	 * @return a mono, emitting a list of mapped entities
+	 */
+	protected <T> Mono<List<T>> zipToPolymorphicList(Stream<EntityVO> entityVOStream,
+			Function<String, Class<? extends T>> typeToClass) {
+		List<Mono<T>> mappingMonos = entityVOStream
+				.map(entityVO -> mapPolymorphicEntity(entityVO, typeToClass))
+				.toList();
+		if (mappingMonos.isEmpty()) {
+			return Mono.just(List.of());
+		}
+		return Mono.zip(mappingMonos, oList -> Arrays.stream(oList).map(o -> (T) o).toList());
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> Mono<T> mapPolymorphicEntity(EntityVO entityVO, Function<String, Class<? extends T>> typeToClass) {
+		Class<? extends T> targetClass = typeToClass.apply(entityVO.getType());
+		return (Mono<T>) entityVOMapper.fromEntityVO(entityVO, targetClass);
 	}
 
 	/**

--- a/common/src/main/java/org/fiware/tmforum/common/repository/PagedResult.java
+++ b/common/src/main/java/org/fiware/tmforum/common/repository/PagedResult.java
@@ -1,0 +1,13 @@
+package org.fiware.tmforum.common.repository;
+
+import java.util.List;
+
+/**
+ * A page of entities together with the offset/limit that produced it and the total number of
+ * entities matching the query, when the target broker reports it (see
+ * {@link org.fiware.tmforum.common.configuration.GeneralProperties#getCountHeader()}).
+ * {@code totalCount} is null when the broker profile has no count header configured, or the broker
+ * didn't send a parsable value for it.
+ */
+public record PagedResult<T>(List<T> items, Integer offset, Integer limit, Integer totalCount) {
+}

--- a/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
+++ b/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
@@ -75,6 +75,7 @@ public class TmForumRepository extends NgsiLdBaseRepository {
                         null,
                         limit,
                         offset,
+                        true,
                         null,
                         getLinkHeader())
                 .flatMap(response -> zipToList(response.body().stream(), entityClass)

--- a/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
+++ b/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
@@ -16,6 +16,7 @@ import reactor.core.publisher.Mono;
 import javax.inject.Singleton;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.function.Function;
 
 @Slf4j
 @Singleton
@@ -90,6 +91,41 @@ public class TmForumRepository extends NgsiLdBaseRepository {
     public <T> Mono<PagedResult<T>> findEntities(Integer offset, Integer limit, String entityType, Class<T> entityClass,
                                           String query) {
         return findEntities(offset, limit, entityClass, query, null, entityType);
+    }
+
+    /**
+     * Query several NGSI-LD entity types in a single broker call (NGSI-LD's {@code type} parameter
+     * accepts a comma-separated list with OR semantics), instead of one call per type. This lets the
+     * broker apply {@code offset}/{@code limit} and report the count against the combined result set,
+     * rather than callers fanning out per-type queries and merging paginated slices themselves.
+     * <p>
+     * Since the result is a mix of entity types, each entity is mapped to its own domain class via
+     * {@code typeToClass} instead of a single fixed class.
+     */
+    public <T> Mono<PagedResult<T>> findEntitiesPolymorphic(Integer offset, Integer limit, String types,
+                                          String query, Function<String, Class<? extends T>> typeToClass) {
+        return entitiesApi.queryEntities(generalProperties.getTenant(),
+                        null,
+                        null,
+                        types,
+                        null,
+                        query,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        limit,
+                        offset,
+                        true,
+                        null,
+                        getLinkHeader())
+                .flatMap(response -> zipToPolymorphicList(response.body().stream(), typeToClass)
+                        .map(entities -> new PagedResult<>(entities, offset, limit, extractTotalCount(response))))
+                .onErrorResume(t -> {
+                    log.warn("Was not able to list entities.", t);
+                    throw new TmForumException("Was not able to list entities.", t, TmForumExceptionReason.UNKNOWN);
+                });
     }
 
     Integer extractTotalCount(HttpResponse<?> response) {

--- a/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
+++ b/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
@@ -10,14 +10,12 @@ import org.fiware.ngsi.api.SubscriptionsApiClient;
 import org.fiware.tmforum.common.configuration.GeneralProperties;
 import org.fiware.tmforum.common.exception.TmForumException;
 import org.fiware.tmforum.common.exception.TmForumExceptionReason;
-import org.fiware.tmforum.common.mapping.IdHelper;
 import org.fiware.tmforum.common.mapping.NGSIMapper;
 import reactor.core.publisher.Mono;
 
 import javax.inject.Singleton;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.List;
 
 @Slf4j
 @Singleton
@@ -62,7 +60,7 @@ public class TmForumRepository extends NgsiLdBaseRepository {
                 .flatMap(entityVO -> entityVOMapper.fromEntityVO(entityVO, entityClass));
     }
 
-    public <T> Mono<List<T>> findEntities(Integer offset, Integer limit, Class<T> entityClass,
+    public <T> Mono<PagedResult<T>> findEntities(Integer offset, Integer limit, Class<T> entityClass,
                                           String query, String ids, String types) {
         return entitiesApi.queryEntities(generalProperties.getTenant(),
                         ids,
@@ -79,9 +77,8 @@ public class TmForumRepository extends NgsiLdBaseRepository {
                         offset,
                         null,
                         getLinkHeader())
-                .map(HttpResponse::body)
-                .map(List::stream)
-                .flatMap(entityVOStream -> zipToList(entityVOStream, entityClass))
+                .flatMap(response -> zipToList(response.body().stream(), entityClass)
+                        .map(entities -> new PagedResult<>(entities, offset, limit, extractTotalCount(response))))
                 .onErrorResume(t -> {
                     log.warn("Was not able to list entities.", t);
                     throw new TmForumException("Was not able to list entities.", t, TmForumExceptionReason.UNKNOWN);
@@ -89,9 +86,26 @@ public class TmForumRepository extends NgsiLdBaseRepository {
     }
 
 
-    public <T> Mono<List<T>> findEntities(Integer offset, Integer limit, String entityType, Class<T> entityClass,
+    public <T> Mono<PagedResult<T>> findEntities(Integer offset, Integer limit, String entityType, Class<T> entityClass,
                                           String query) {
         return findEntities(offset, limit, entityClass, query, null, entityType);
+    }
+
+    Integer extractTotalCount(HttpResponse<?> response) {
+        String headerName = generalProperties.getCountHeader();
+        if (headerName == null) {
+            return null;
+        }
+        String headerValue = response.header(headerName);
+        if (headerValue == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(headerValue);
+        } catch (NumberFormatException e) {
+            log.warn("Total count header {} did not contain a valid integer: {}", headerName, headerValue);
+            return null;
+        }
     }
 
 }

--- a/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
+++ b/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
@@ -62,13 +62,14 @@ public class TmForumRepository extends NgsiLdBaseRepository {
     }
 
     public <T> Mono<PagedResult<T>> findEntities(Integer offset, Integer limit, Class<T> entityClass,
-                                          String query, String ids, String types) {
+                                          String query, String ids, String types, String orderBy) {
         return entitiesApi.queryEntities(generalProperties.getTenant(),
                         ids,
                         null,
                         types,
                         null,
                         query,
+                        orderBy,
                         null,
                         null,
                         null,
@@ -90,7 +91,7 @@ public class TmForumRepository extends NgsiLdBaseRepository {
 
     public <T> Mono<PagedResult<T>> findEntities(Integer offset, Integer limit, String entityType, Class<T> entityClass,
                                           String query) {
-        return findEntities(offset, limit, entityClass, query, null, entityType);
+        return findEntities(offset, limit, entityClass, query, null, entityType, null);
     }
 
     /**
@@ -103,13 +104,14 @@ public class TmForumRepository extends NgsiLdBaseRepository {
      * {@code typeToClass} instead of a single fixed class.
      */
     public <T> Mono<PagedResult<T>> findEntitiesPolymorphic(Integer offset, Integer limit, String types,
-                                          String query, Function<String, Class<? extends T>> typeToClass) {
+                                          String query, String orderBy, Function<String, Class<? extends T>> typeToClass) {
         return entitiesApi.queryEntities(generalProperties.getTenant(),
                         null,
                         null,
                         types,
                         null,
                         query,
+                        orderBy,
                         null,
                         null,
                         null,

--- a/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
+++ b/common/src/main/java/org/fiware/tmforum/common/repository/TmForumRepository.java
@@ -3,6 +3,7 @@ package org.fiware.tmforum.common.repository;
 import io.github.wistefan.mapping.EntityVOMapper;
 import io.github.wistefan.mapping.JavaObjectMapper;
 import io.github.wistefan.mapping.annotations.MappingEnabled;
+import io.micronaut.http.HttpResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.fiware.ngsi.api.EntitiesApiClient;
 import org.fiware.ngsi.api.SubscriptionsApiClient;
@@ -78,6 +79,7 @@ public class TmForumRepository extends NgsiLdBaseRepository {
                         offset,
                         null,
                         getLinkHeader())
+                .map(HttpResponse::body)
                 .map(List::stream)
                 .flatMap(entityVOStream -> zipToList(entityVOStream, entityClass))
                 .onErrorResume(t -> {

--- a/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
+++ b/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.fiware.tmforum.common.CommonConstants.DEFAULT_LIMIT;
@@ -122,6 +123,59 @@ public abstract class AbstractApiController<T> {
 						Optional.ofNullable(queryParams).map(QueryParams::query).orElse(null),
 						Optional.ofNullable(queryParams).map(QueryParams::id).orElse(null),
 						Optional.ofNullable(queryParams).map(QueryParams::type).orElse(type))
+				.doOnNext(pagedResult -> optionalHttpRequest.ifPresent(theRequest -> {
+					theRequest.setAttribute(PaginationFilter.OFFSET_ATTR, pagedResult.offset())
+							.setAttribute(PaginationFilter.LIMIT_ATTR, pagedResult.limit())
+							.setAttribute(PaginationFilter.RETURNED_COUNT_ATTR, pagedResult.items().size());
+					if (pagedResult.totalCount() != null) {
+						theRequest.setAttribute(PaginationFilter.TOTAL_COUNT_ATTR, pagedResult.totalCount());
+					}
+				}))
+				.map(PagedResult::items)
+				.map(List::stream);
+	}
+
+	/**
+	 * List entities of several NGSI-LD types at once (e.g. a base type and all its registered
+	 * sub-types), in a single broker call, so that offset/limit/count are correct against the
+	 * combined result set instead of being computed by fanning out one query per type and merging
+	 * paginated slices client-side.
+	 *
+	 * @param offset      requested offset
+	 * @param limit       requested limit
+	 * @param types       comma-separated list of NGSI-LD types to query (OR semantics)
+	 * @param queryClass  class used to resolve/validate filter attributes from the request's query string
+	 * @param typeToClass resolves the domain class to map an entity to, based on its NGSI-LD type
+	 */
+	protected <R> Mono<Stream<R>> listPolymorphic(Integer offset, Integer limit, String types,
+			Class<R> queryClass, Function<String, Class<? extends R>> typeToClass) {
+
+		Optional<HttpRequest<Object>> optionalHttpRequest = ServerRequestContext.currentRequest();
+		QueryParams queryParams = null;
+		if (optionalHttpRequest.isEmpty()) {
+			log.warn("The original request is not available, no filters will be applied.");
+		} else {
+			HttpRequest<Object> theRequest = optionalHttpRequest.get();
+			Map<String, List<String>> parameters = theRequest.getParameters().asMap();
+			if (QueryParser.hasFilter(parameters)) {
+				log.debug("A filter is included in the request.");
+				String queryString = theRequest.getUri().getQuery();
+				queryParams = queryParser.toNgsiLdQuery(queryClass, queryString);
+			}
+		}
+		offset = Optional.ofNullable(offset).orElse(DEFAULT_OFFSET);
+		limit = Optional.ofNullable(limit).orElse(DEFAULT_LIMIT);
+
+		if (offset < 0 || limit < 1) {
+			throw new TmForumException(String.format("Invalid offset %s or limit %s.", offset, limit),
+					TmForumExceptionReason.INVALID_DATA);
+		}
+
+		return repository
+				.findEntitiesPolymorphic(offset, limit,
+						Optional.ofNullable(queryParams).map(QueryParams::type).orElse(types),
+						Optional.ofNullable(queryParams).map(QueryParams::query).orElse(null),
+						typeToClass)
 				.doOnNext(pagedResult -> optionalHttpRequest.ifPresent(theRequest -> {
 					theRequest.setAttribute(PaginationFilter.OFFSET_ATTR, pagedResult.offset())
 							.setAttribute(PaginationFilter.LIMIT_ATTR, pagedResult.limit())

--- a/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
+++ b/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
@@ -99,11 +99,14 @@ public abstract class AbstractApiController<T> {
 
 		Optional<HttpRequest<Object>> optionalHttpRequest = ServerRequestContext.currentRequest();
 		QueryParams queryParams = null;
+		String orderBy = null;
 		if (optionalHttpRequest.isEmpty()) {
 			log.warn("The original request is not available, no filters will be applied.");
 		} else {
 			HttpRequest<Object> theRequest = optionalHttpRequest.get();
 			Map<String, List<String>> parameters = theRequest.getParameters().asMap();
+			// resolve orderBy before hasFilter, which mutates parameters by removing well-known keys (incl. sort)
+			orderBy = queryParser.toOrderBy(entityClass, parameters);
 			if (QueryParser.hasFilter(parameters)) {
 				log.debug("A filter is included in the request.");
 				String queryString = theRequest.getUri().getQuery();
@@ -122,7 +125,8 @@ public abstract class AbstractApiController<T> {
 				.findEntities(offset, limit, entityClass,
 						Optional.ofNullable(queryParams).map(QueryParams::query).orElse(null),
 						Optional.ofNullable(queryParams).map(QueryParams::id).orElse(null),
-						Optional.ofNullable(queryParams).map(QueryParams::type).orElse(type))
+						Optional.ofNullable(queryParams).map(QueryParams::type).orElse(type),
+						orderBy)
 				.doOnNext(pagedResult -> optionalHttpRequest.ifPresent(theRequest -> {
 					theRequest.setAttribute(PaginationFilter.OFFSET_ATTR, pagedResult.offset())
 							.setAttribute(PaginationFilter.LIMIT_ATTR, pagedResult.limit())
@@ -152,11 +156,14 @@ public abstract class AbstractApiController<T> {
 
 		Optional<HttpRequest<Object>> optionalHttpRequest = ServerRequestContext.currentRequest();
 		QueryParams queryParams = null;
+		String orderBy = null;
 		if (optionalHttpRequest.isEmpty()) {
 			log.warn("The original request is not available, no filters will be applied.");
 		} else {
 			HttpRequest<Object> theRequest = optionalHttpRequest.get();
 			Map<String, List<String>> parameters = theRequest.getParameters().asMap();
+			// resolve orderBy before hasFilter, which mutates parameters by removing well-known keys (incl. sort)
+			orderBy = queryParser.toOrderBy(queryClass, parameters);
 			if (QueryParser.hasFilter(parameters)) {
 				log.debug("A filter is included in the request.");
 				String queryString = theRequest.getUri().getQuery();
@@ -175,6 +182,7 @@ public abstract class AbstractApiController<T> {
 				.findEntitiesPolymorphic(offset, limit,
 						Optional.ofNullable(queryParams).map(QueryParams::type).orElse(types),
 						Optional.ofNullable(queryParams).map(QueryParams::query).orElse(null),
+						orderBy,
 						typeToClass)
 				.doOnNext(pagedResult -> optionalHttpRequest.ifPresent(theRequest -> {
 					theRequest.setAttribute(PaginationFilter.OFFSET_ATTR, pagedResult.offset())

--- a/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
+++ b/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
@@ -14,6 +14,7 @@ import org.fiware.tmforum.common.mapping.IdHelper;
 import org.fiware.tmforum.common.notification.TMForumEventHandler;
 import org.fiware.tmforum.common.querying.QueryParams;
 import org.fiware.tmforum.common.querying.QueryParser;
+import org.fiware.tmforum.common.repository.PagedResult;
 import org.fiware.tmforum.common.repository.TmForumRepository;
 import org.fiware.tmforum.common.validation.ReferenceValidationService;
 import org.fiware.tmforum.common.validation.ReferencedEntity;
@@ -116,17 +117,20 @@ public abstract class AbstractApiController<T> {
 					TmForumExceptionReason.INVALID_DATA);
 		}
 
-		int resolvedOffset = offset;
-		int resolvedLimit = limit;
 		return repository
 				.findEntities(offset, limit, entityClass,
 						Optional.ofNullable(queryParams).map(QueryParams::query).orElse(null),
 						Optional.ofNullable(queryParams).map(QueryParams::id).orElse(null),
 						Optional.ofNullable(queryParams).map(QueryParams::type).orElse(type))
-				.doOnNext(entities -> optionalHttpRequest.ifPresent(theRequest ->
-						theRequest.setAttribute(PaginationFilter.OFFSET_ATTR, resolvedOffset)
-								.setAttribute(PaginationFilter.LIMIT_ATTR, resolvedLimit)
-								.setAttribute(PaginationFilter.RETURNED_COUNT_ATTR, entities.size())))
+				.doOnNext(pagedResult -> optionalHttpRequest.ifPresent(theRequest -> {
+					theRequest.setAttribute(PaginationFilter.OFFSET_ATTR, pagedResult.offset())
+							.setAttribute(PaginationFilter.LIMIT_ATTR, pagedResult.limit())
+							.setAttribute(PaginationFilter.RETURNED_COUNT_ATTR, pagedResult.items().size());
+					if (pagedResult.totalCount() != null) {
+						theRequest.setAttribute(PaginationFilter.TOTAL_COUNT_ATTR, pagedResult.totalCount());
+					}
+				}))
+				.map(PagedResult::items)
 				.map(List::stream);
 	}
 

--- a/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
+++ b/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.fiware.tmforum.common.domain.EntityWithId;
 import org.fiware.tmforum.common.exception.TmForumException;
 import org.fiware.tmforum.common.exception.TmForumExceptionReason;
+import org.fiware.tmforum.common.filter.PaginationFilter;
 import org.fiware.tmforum.common.mapping.IdHelper;
 import org.fiware.tmforum.common.notification.TMForumEventHandler;
 import org.fiware.tmforum.common.querying.QueryParams;
@@ -115,11 +116,17 @@ public abstract class AbstractApiController<T> {
 					TmForumExceptionReason.INVALID_DATA);
 		}
 
+		int resolvedOffset = offset;
+		int resolvedLimit = limit;
 		return repository
 				.findEntities(offset, limit, entityClass,
 						Optional.ofNullable(queryParams).map(QueryParams::query).orElse(null),
 						Optional.ofNullable(queryParams).map(QueryParams::id).orElse(null),
 						Optional.ofNullable(queryParams).map(QueryParams::type).orElse(type))
+				.doOnNext(entities -> optionalHttpRequest.ifPresent(theRequest ->
+						theRequest.setAttribute(PaginationFilter.OFFSET_ATTR, resolvedOffset)
+								.setAttribute(PaginationFilter.LIMIT_ATTR, resolvedLimit)
+								.setAttribute(PaginationFilter.RETURNED_COUNT_ATTR, entities.size())))
 				.map(List::stream);
 	}
 

--- a/common/src/main/java/org/fiware/tmforum/common/rest/AbstractSubscriptionApiController.java
+++ b/common/src/main/java/org/fiware/tmforum/common/rest/AbstractSubscriptionApiController.java
@@ -28,6 +28,7 @@ import org.fiware.tmforum.common.notification.TMForumEventHandler;
 import org.fiware.tmforum.common.querying.QueryParser;
 import org.fiware.tmforum.common.querying.SubscriptionQuery;
 import org.fiware.tmforum.common.querying.SubscriptionQueryParser;
+import org.fiware.tmforum.common.repository.PagedResult;
 import org.fiware.tmforum.common.repository.TmForumRepository;
 import org.fiware.tmforum.common.validation.ReferenceValidationService;
 import reactor.core.publisher.Mono;
@@ -100,6 +101,7 @@ public abstract class AbstractSubscriptionApiController extends AbstractApiContr
 
 		return repository.findEntities(CommonConstants.DEFAULT_OFFSET, 1, TMForumSubscription.TYPE_TM_FORUM_SUBSCRIPTION,
 						TMForumSubscription.class, query)
+				.map(PagedResult::items)
 				.flatMap(list -> list.isEmpty() ? Mono.empty() :
 						Mono.error(new TmForumException("Such subscription already exists.", TmForumExceptionReason.CONFLICT)));
 	}

--- a/common/src/main/java/org/fiware/tmforum/common/test/AbstractApiIT.java
+++ b/common/src/main/java/org/fiware/tmforum/common/test/AbstractApiIT.java
@@ -58,7 +58,9 @@ public abstract class AbstractApiIT {
                 1000,
                 0,
                 null,
-                getLinkHeader(generalProperties.getContextUrl())).block();
+                getLinkHeader(generalProperties.getContextUrl()))
+                .map(HttpResponse::body)
+                .block();
         entityVOS.stream()
                 .filter(Objects::nonNull)
                 .map(EntityVO::getId)

--- a/common/src/main/java/org/fiware/tmforum/common/test/AbstractApiIT.java
+++ b/common/src/main/java/org/fiware/tmforum/common/test/AbstractApiIT.java
@@ -1,6 +1,5 @@
 package org.fiware.tmforum.common.test;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.wistefan.mapping.AdditionalPropertyMixin;
 import io.micronaut.http.HttpResponse;
@@ -57,6 +56,7 @@ public abstract class AbstractApiIT {
                 null,
                 1000,
                 0,
+                false,
                 null,
                 getLinkHeader(generalProperties.getContextUrl()))
                 .map(HttpResponse::body)

--- a/common/src/main/java/org/fiware/tmforum/common/test/AbstractApiIT.java
+++ b/common/src/main/java/org/fiware/tmforum/common/test/AbstractApiIT.java
@@ -54,6 +54,7 @@ public abstract class AbstractApiIT {
                 null,
                 null,
                 null,
+                null,
                 1000,
                 0,
                 false,

--- a/common/src/test/java/org/fiware/tmforum/common/filter/PaginationFilterTest.java
+++ b/common/src/test/java/org/fiware/tmforum/common/filter/PaginationFilterTest.java
@@ -1,6 +1,9 @@
 package org.fiware.tmforum.common.filter;
 
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpResponse;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -8,17 +11,19 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PaginationFilterTest {
 
 	private static final URI BASE_URI = URI.create("https://example.com");
+	private final PaginationFilter filter = new PaginationFilter();
 
 	@Test
 	public void fullPageInTheMiddleHasAllFourLinks() {
 		HttpRequest<?> request = HttpRequest.GET("/resource?fields=name&offset=10&limit=10");
 
-		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 10, 10, 10);
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 10, 10, 10, null);
 
 		assertEquals(4, entries.size(), "self/first/prev/next should all be present.");
 		assertTrue(entries.get(0).contains("offset=10") && entries.get(0).contains("rel=\"self\""));
@@ -33,7 +38,7 @@ class PaginationFilterTest {
 	public void firstPageOmitsPrev() {
 		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10");
 
-		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 0, 10, 10);
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 0, 10, 10, null);
 
 		assertEquals(3, entries.size(), "prev should be omitted on the first page.");
 		assertTrue(entries.stream().noneMatch(e -> e.contains("rel=\"prev\"")));
@@ -43,7 +48,7 @@ class PaginationFilterTest {
 	public void partialPageOmitsNext() {
 		HttpRequest<?> request = HttpRequest.GET("/resource?offset=10&limit=10");
 
-		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 10, 10, 5);
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 10, 10, 5, null);
 
 		assertFalse(entries.stream().anyMatch(e -> e.contains("rel=\"next\"")),
 				"A page returning fewer items than the limit is assumed to be the last one.");
@@ -53,7 +58,7 @@ class PaginationFilterTest {
 	public void prevIsClampedToZero() {
 		HttpRequest<?> request = HttpRequest.GET("/resource?offset=5&limit=10");
 
-		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 5, 10, 10);
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 5, 10, 10, null);
 
 		String prev = entries.stream().filter(e -> e.contains("rel=\"prev\"")).findFirst().orElseThrow();
 		assertTrue(prev.contains("offset=0"), "prev must not go negative: " + prev);
@@ -64,9 +69,96 @@ class PaginationFilterTest {
 		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10");
 		URI prefixedBaseUri = URI.create("https://example.com/api/v1");
 
-		List<String> entries = PaginationFilter.buildLinkEntries(request, prefixedBaseUri, 0, 10, 10);
+		List<String> entries = PaginationFilter.buildLinkEntries(request, prefixedBaseUri, 0, 10, 10, null);
 
 		entries.forEach(entry -> assertTrue(entry.contains("https://example.com/api/v1/resource"),
 				"The forwarded prefix must be kept ahead of the resource path: " + entry));
+	}
+
+	@Test
+	public void withTotalCountNextIsExactRatherThanHeuristic() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=10&limit=10");
+
+		// returnedCount == limit, so the heuristic would say "next", but total says this is the last page.
+		List<String> exactlyAtTotal = PaginationFilter.buildLinkEntries(request, BASE_URI, 10, 10, 10, 20);
+		assertFalse(exactlyAtTotal.stream().anyMatch(e -> e.contains("rel=\"next\"")),
+				"offset+limit == total means there is no next page, even though the page came back full.");
+
+		List<String> beforeTotal = PaginationFilter.buildLinkEntries(request, BASE_URI, 10, 10, 10, 25);
+		assertTrue(beforeTotal.stream().anyMatch(e -> e.contains("rel=\"next\"") && e.contains("offset=20")));
+	}
+
+	@Test
+	public void lastLinkIsOnlyAddedWithATotalCount() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10");
+
+		List<String> withoutTotal = PaginationFilter.buildLinkEntries(request, BASE_URI, 0, 10, 10, null);
+		assertFalse(withoutTotal.stream().anyMatch(e -> e.contains("rel=\"last\"")),
+				"last cannot be computed without a total count.");
+
+		// 25 items, limit 10 -> pages at offset 0, 10, 20 -> last page starts at offset 20.
+		List<String> withTotal = PaginationFilter.buildLinkEntries(request, BASE_URI, 0, 10, 10, 25);
+		String last = withTotal.stream().filter(e -> e.contains("rel=\"last\"")).findFirst().orElseThrow();
+		assertTrue(last.contains("offset=20"), "last must point at the final page: " + last);
+	}
+
+	@Test
+	public void lastLinkWithZeroTotalPointsAtOffsetZero() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10");
+
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 0, 10, 0, 0);
+
+		String last = entries.stream().filter(e -> e.contains("rel=\"last\"")).findFirst().orElseThrow();
+		assertTrue(last.contains("offset=0"), "An empty result set's last page is offset 0: " + last);
+	}
+
+	@Test
+	public void isPartialOnlyWhenTotalCountIsKnownAndGreaterThanReturned() {
+		assertFalse(PaginationFilter.isPartial(10, null), "Unknown total must never claim partial.");
+		assertFalse(PaginationFilter.isPartial(10, 10), "A full result set is not partial.");
+		assertTrue(PaginationFilter.isPartial(10, 25), "Fewer items returned than the total is partial.");
+	}
+
+	@Test
+	public void addPaginationLinkSetsTotalCountHeaderAndPartialStatus() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10")
+				.setAttribute(PaginationFilter.OFFSET_ATTR, 0)
+				.setAttribute(PaginationFilter.LIMIT_ATTR, 10)
+				.setAttribute(PaginationFilter.RETURNED_COUNT_ATTR, 10)
+				.setAttribute(PaginationFilter.TOTAL_COUNT_ATTR, 25);
+		MutableHttpResponse<Object> response = HttpResponse.ok();
+
+		filter.addPaginationLink(request, response);
+
+		assertEquals("25", response.getHeaders().get("X-Total-Count"));
+		assertEquals(HttpStatus.PARTIAL_CONTENT, response.getStatus());
+	}
+
+	@Test
+	public void addPaginationLinkKeeps200WhenResultIsComplete() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10")
+				.setAttribute(PaginationFilter.OFFSET_ATTR, 0)
+				.setAttribute(PaginationFilter.LIMIT_ATTR, 10)
+				.setAttribute(PaginationFilter.RETURNED_COUNT_ATTR, 10)
+				.setAttribute(PaginationFilter.TOTAL_COUNT_ATTR, 10);
+		MutableHttpResponse<Object> response = HttpResponse.ok();
+
+		filter.addPaginationLink(request, response);
+
+		assertEquals(HttpStatus.OK, response.getStatus());
+	}
+
+	@Test
+	public void addPaginationLinkOmitsTotalCountHeaderWhenNotConfigured() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10")
+				.setAttribute(PaginationFilter.OFFSET_ATTR, 0)
+				.setAttribute(PaginationFilter.LIMIT_ATTR, 10)
+				.setAttribute(PaginationFilter.RETURNED_COUNT_ATTR, 10);
+		MutableHttpResponse<Object> response = HttpResponse.ok();
+
+		filter.addPaginationLink(request, response);
+
+		assertNull(response.getHeaders().get("X-Total-Count"));
+		assertEquals(HttpStatus.OK, response.getStatus());
 	}
 }

--- a/common/src/test/java/org/fiware/tmforum/common/filter/PaginationFilterTest.java
+++ b/common/src/test/java/org/fiware/tmforum/common/filter/PaginationFilterTest.java
@@ -1,0 +1,72 @@
+package org.fiware.tmforum.common.filter;
+
+import io.micronaut.http.HttpRequest;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PaginationFilterTest {
+
+	private static final URI BASE_URI = URI.create("https://example.com");
+
+	@Test
+	public void fullPageInTheMiddleHasAllFourLinks() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?fields=name&offset=10&limit=10");
+
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 10, 10, 10);
+
+		assertEquals(4, entries.size(), "self/first/prev/next should all be present.");
+		assertTrue(entries.get(0).contains("offset=10") && entries.get(0).contains("rel=\"self\""));
+		assertTrue(entries.get(1).contains("offset=0") && entries.get(1).contains("rel=\"first\""));
+		assertTrue(entries.get(2).contains("offset=0") && entries.get(2).contains("rel=\"prev\""));
+		assertTrue(entries.get(3).contains("offset=20") && entries.get(3).contains("rel=\"next\""));
+		entries.forEach(entry -> assertTrue(entry.contains("fields=name"), "Other query params must survive: " + entry));
+		entries.forEach(entry -> assertTrue(entry.startsWith("<https://example.com/resource?"), "Must use the forwarded base URI: " + entry));
+	}
+
+	@Test
+	public void firstPageOmitsPrev() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10");
+
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 0, 10, 10);
+
+		assertEquals(3, entries.size(), "prev should be omitted on the first page.");
+		assertTrue(entries.stream().noneMatch(e -> e.contains("rel=\"prev\"")));
+	}
+
+	@Test
+	public void partialPageOmitsNext() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=10&limit=10");
+
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 10, 10, 5);
+
+		assertFalse(entries.stream().anyMatch(e -> e.contains("rel=\"next\"")),
+				"A page returning fewer items than the limit is assumed to be the last one.");
+	}
+
+	@Test
+	public void prevIsClampedToZero() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=5&limit=10");
+
+		List<String> entries = PaginationFilter.buildLinkEntries(request, BASE_URI, 5, 10, 10);
+
+		String prev = entries.stream().filter(e -> e.contains("rel=\"prev\"")).findFirst().orElseThrow();
+		assertTrue(prev.contains("offset=0"), "prev must not go negative: " + prev);
+	}
+
+	@Test
+	public void baseUriPrefixIsPreserved() {
+		HttpRequest<?> request = HttpRequest.GET("/resource?offset=0&limit=10");
+		URI prefixedBaseUri = URI.create("https://example.com/api/v1");
+
+		List<String> entries = PaginationFilter.buildLinkEntries(request, prefixedBaseUri, 0, 10, 10);
+
+		entries.forEach(entry -> assertTrue(entry.contains("https://example.com/api/v1/resource"),
+				"The forwarded prefix must be kept ahead of the resource path: " + entry));
+	}
+}

--- a/common/src/test/java/org/fiware/tmforum/common/querying/QueryParserTest.java
+++ b/common/src/test/java/org/fiware/tmforum/common/querying/QueryParserTest.java
@@ -6,9 +6,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class QueryParserTest {
 
@@ -209,5 +212,48 @@ class QueryParserTest {
 						new QueryParams("urn:x", null, "atType==\"A\""),
 						MyEntityPojo.class)
 		);
+	}
+
+	/**
+	 * Verifies the translation of the TMForum {@code sort} query parameter (comma-separated
+	 * properties, "-" prefix for descending) into NGSI-LD's {@code orderBy} syntax
+	 * (comma-separated "property;direction" pairs, direction omitted meaning ascending).
+	 */
+	@ParameterizedTest
+	@MethodSource("sortToOrderByQueries")
+	public void testSortToOrderByTranslation(Map<String, List<String>> parameters, String expectedOrderBy,
+			Class<?> targetClass) {
+		GeneralProperties properties = new GeneralProperties();
+		properties.setUseDotSeperator(true);
+
+		QueryParser qp = new QueryParser(properties);
+		assertEquals(expectedOrderBy, qp.toOrderBy(targetClass, parameters),
+				"The sort parameter should have been properly translated to orderBy.");
+	}
+
+	private static Stream<Arguments> sortToOrderByQueries() {
+		return Stream.of(
+				// no sort requested at all
+				Arguments.of(Map.of(), null, MyPojo.class),
+				// single ascending field, no direction suffix needed
+				Arguments.of(Map.of(QueryParser.SORT_KEY, List.of("color")), "color", MyPojo.class),
+				// single descending field
+				Arguments.of(Map.of(QueryParser.SORT_KEY, List.of("-color")), "color;desc", MyPojo.class),
+				// mixed ascending/descending, comma-separated
+				Arguments.of(Map.of(QueryParser.SORT_KEY, List.of("color,-temperature")), "color,temperature;desc", MyPojo.class),
+				Arguments.of(Map.of(QueryParser.SORT_KEY, List.of("-color,-temperature")), "color;desc,temperature;desc", MyPojo.class),
+				// nested attribute path
+				Arguments.of(Map.of(QueryParser.SORT_KEY, List.of("-sub.status")), "sub.status;desc", MyPojo.class),
+				// JSON-LD reserved token translation, same as filtering
+				Arguments.of(Map.of(QueryParser.SORT_KEY, List.of("-@type")), "atType;desc", MyEntityPojo.class)
+		);
+	}
+
+	@Test
+	public void testSortToOrderByReturnsNullWhenSortValueIsBlank() {
+		GeneralProperties properties = new GeneralProperties();
+		QueryParser qp = new QueryParser(properties);
+		assertNull(qp.toOrderBy(MyPojo.class, Map.of(QueryParser.SORT_KEY, List.of(""))),
+				"A blank sort value should not produce an orderBy.");
 	}
 }

--- a/common/src/test/java/org/fiware/tmforum/common/repository/TmForumRepositoryTest.java
+++ b/common/src/test/java/org/fiware/tmforum/common/repository/TmForumRepositoryTest.java
@@ -29,6 +29,7 @@ class TmForumRepositoryTest {
 
 	@Test
 	public void returnsNullWhenNoHeaderIsConfigured() {
+		properties.setCountHeader(null);
 		HttpResponse<Object> response = HttpResponse.ok().header("NGSILD-Results-Count", "42");
 
 		assertNull(repository.extractTotalCount(response),

--- a/common/src/test/java/org/fiware/tmforum/common/repository/TmForumRepositoryTest.java
+++ b/common/src/test/java/org/fiware/tmforum/common/repository/TmForumRepositoryTest.java
@@ -1,0 +1,54 @@
+package org.fiware.tmforum.common.repository;
+
+import io.micronaut.http.HttpResponse;
+import org.fiware.tmforum.common.configuration.GeneralProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TmForumRepositoryTest {
+
+	private GeneralProperties properties;
+	private TmForumRepository repository;
+
+	@BeforeEach
+	public void setUp() {
+		properties = new GeneralProperties();
+		repository = new TmForumRepository(properties, null, null, null, null, null);
+	}
+
+	@Test
+	public void extractsTheConfiguredHeader() {
+		properties.setCountHeader("NGSILD-Results-Count");
+		HttpResponse<Object> response = HttpResponse.ok().header("NGSILD-Results-Count", "42");
+
+		assertEquals(42, repository.extractTotalCount(response));
+	}
+
+	@Test
+	public void returnsNullWhenNoHeaderIsConfigured() {
+		HttpResponse<Object> response = HttpResponse.ok().header("NGSILD-Results-Count", "42");
+
+		assertNull(repository.extractTotalCount(response),
+				"Without a configured header name, the total is unknown even if the broker sent one.");
+	}
+
+	@Test
+	public void returnsNullWhenTheBrokerDidNotSendTheHeader() {
+		properties.setCountHeader("NGSILD-Results-Count");
+		HttpResponse<Object> response = HttpResponse.ok();
+
+		assertNull(repository.extractTotalCount(response));
+	}
+
+	@Test
+	public void returnsNullWhenTheHeaderIsNotAnInteger() {
+		properties.setCountHeader("NGSILD-Results-Count");
+		HttpResponse<Object> response = HttpResponse.ok().header("NGSILD-Results-Count", "not-a-number");
+
+		assertNull(repository.extractTotalCount(response),
+				"A malformed header must degrade to unknown, not fail the request.");
+	}
+}

--- a/customer-bill-management/src/main/resources/application-orion-ld.yaml
+++ b/customer-bill-management/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/customer-bill-management/src/main/resources/application-orion-ld.yaml
+++ b/customer-bill-management/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/customer-bill-management/src/main/resources/application-scorpio.yaml
+++ b/customer-bill-management/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/customer-bill-management/src/main/resources/application.yaml
+++ b/customer-bill-management/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 
 apiExtension:
   # we reference the env var here directly, since property resolution from env vars happens AFTER evaluation of @Requires

--- a/customer-management/src/main/resources/application-orion-ld.yaml
+++ b/customer-management/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/customer-management/src/main/resources/application-orion-ld.yaml
+++ b/customer-management/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/customer-management/src/main/resources/application-scorpio.yaml
+++ b/customer-management/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/customer-management/src/main/resources/application.yaml
+++ b/customer-management/src/main/resources/application.yaml
@@ -36,6 +36,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   customer-management:
     basepath: ${general.basepath:/}

--- a/data-migrator/migrator/src/main/resources/application.yaml
+++ b/data-migrator/migrator/src/main/resources/application.yaml
@@ -19,5 +19,6 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8634
+  countHeader: NGSILD-Results-Count
 mapping:
   strictRelationships: false

--- a/document-management/src/main/resources/application.yaml
+++ b/document-management/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8667
+  countHeader: NGSILD-Results-Count
 
 api:
   document-management:

--- a/party-catalog/src/main/resources/application-orion-ld.yaml
+++ b/party-catalog/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/party-catalog/src/main/resources/application-orion-ld.yaml
+++ b/party-catalog/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/party-catalog/src/main/resources/application-scorpio.yaml
+++ b/party-catalog/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/party-catalog/src/main/resources/application.yaml
+++ b/party-catalog/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 
 api:
   party-catalog:

--- a/party-role/src/main/resources/application-orion-ld.yaml
+++ b/party-role/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/party-role/src/main/resources/application-orion-ld.yaml
+++ b/party-role/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/party-role/src/main/resources/application-scorpio.yaml
+++ b/party-role/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/party-role/src/main/resources/application.yaml
+++ b/party-role/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   party-role:
     basepath: ${general.basepath:/}

--- a/party-role/src/test/java/org/fiware/tmforum/partyrole/PartyRoleApiIT.java
+++ b/party-role/src/test/java/org/fiware/tmforum/partyrole/PartyRoleApiIT.java
@@ -270,8 +270,8 @@ public class PartyRoleApiIT extends AbstractApiIT implements PartyRoleApiTestSpe
 		Integer limit = 5;
 		listResponse = callAndCatch(
 				() -> prApiTestClient.listPartyRole(null, null, null, limit));
-		assertEquals(HttpStatus.OK, listResponse.getStatus(),
-				"PartyRole list should be accessible");
+		assertEquals(HttpStatus.PARTIAL_CONTENT, listResponse.getStatus(),
+				"A page that doesn't contain the full result set must be reported as 206, per TMF630.");
 		assertEquals(limit, listResponse.body().size(),
 				"The number of party roles should be the same");
 	}

--- a/party-role/src/test/resources/application-orion-ld.yaml
+++ b/party-role/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/party-role/src/test/resources/application-orion-ld.yaml
+++ b/party-role/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/party-role/src/test/resources/application-scorpio.yaml
+++ b/party-role/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <version.io.kokuwa.micronaut.codegen>4.4.1</version.io.kokuwa.micronaut.codegen>
 
         <!-- mapping -->
-        <version.io.github.wistefan.ngsi-ld-mapping-java>1.6.17</version.io.github.wistefan.ngsi-ld-mapping-java>
+        <version.io.github.wistefan.ngsi-ld-mapping-java>1.6.18</version.io.github.wistefan.ngsi-ld-mapping-java>
 
         <!-- caching -->
         <version.io.micronaut.redis.micronaut-redis-lettuce>5.4.0</version.io.micronaut.redis.micronaut-redis-lettuce>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <version.io.kokuwa.micronaut.codegen>4.4.1</version.io.kokuwa.micronaut.codegen>
 
         <!-- mapping -->
-        <version.io.github.wistefan.ngsi-ld-mapping-java>1.6.16</version.io.github.wistefan.ngsi-ld-mapping-java>
+        <version.io.github.wistefan.ngsi-ld-mapping-java>1.6.17</version.io.github.wistefan.ngsi-ld-mapping-java>
 
         <!-- caching -->
         <version.io.micronaut.redis.micronaut-redis-lettuce>5.4.0</version.io.micronaut.redis.micronaut-redis-lettuce>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <version.io.kokuwa.micronaut.codegen>4.4.1</version.io.kokuwa.micronaut.codegen>
 
         <!-- mapping -->
-        <version.io.github.wistefan.ngsi-ld-mapping-java>1.6.18</version.io.github.wistefan.ngsi-ld-mapping-java>
+        <version.io.github.wistefan.ngsi-ld-mapping-java>1.6.20</version.io.github.wistefan.ngsi-ld-mapping-java>
 
         <!-- caching -->
         <version.io.micronaut.redis.micronaut-redis-lettuce>5.4.0</version.io.micronaut.redis.micronaut-redis-lettuce>

--- a/product-catalog/src/main/resources/application-orion-ld.yaml
+++ b/product-catalog/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/product-catalog/src/main/resources/application-orion-ld.yaml
+++ b/product-catalog/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/product-catalog/src/main/resources/application-scorpio.yaml
+++ b/product-catalog/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/product-catalog/src/main/resources/application.yaml
+++ b/product-catalog/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   product-catalog:
     basepath: ${general.basepath:/}

--- a/product-catalog/src/test/resources/application-orion-ld.yaml
+++ b/product-catalog/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/product-catalog/src/test/resources/application-orion-ld.yaml
+++ b/product-catalog/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/product-catalog/src/test/resources/application-scorpio.yaml
+++ b/product-catalog/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count

--- a/product-inventory/src/main/resources/application-orion-ld.yaml
+++ b/product-inventory/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/product-inventory/src/main/resources/application-orion-ld.yaml
+++ b/product-inventory/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/product-inventory/src/main/resources/application-scorpio.yaml
+++ b/product-inventory/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/product-inventory/src/main/resources/application.yaml
+++ b/product-inventory/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   product-inventory:
     basepath: ${general.basepath:/}

--- a/product-inventory/src/test/resources/application-orion-ld.yaml
+++ b/product-inventory/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/product-inventory/src/test/resources/application-orion-ld.yaml
+++ b/product-inventory/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/product-inventory/src/test/resources/application-scorpio.yaml
+++ b/product-inventory/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count

--- a/product-ordering-management/src/main/resources/application-orion-ld.yaml
+++ b/product-ordering-management/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/product-ordering-management/src/main/resources/application-orion-ld.yaml
+++ b/product-ordering-management/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/product-ordering-management/src/main/resources/application-scorpio.yaml
+++ b/product-ordering-management/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/product-ordering-management/src/main/resources/application.yaml
+++ b/product-ordering-management/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   product-ordering-management:
     basepath: ${general.basepath:/}

--- a/quote/src/main/resources/application-orion-ld.yaml
+++ b/quote/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/quote/src/main/resources/application-orion-ld.yaml
+++ b/quote/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/quote/src/main/resources/application-scorpio.yaml
+++ b/quote/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/quote/src/main/resources/application.yaml
+++ b/quote/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   quote:
     basepath: ${general.basepath:/}

--- a/quote/src/test/resources/application-orion-ld.yaml
+++ b/quote/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/quote/src/test/resources/application-orion-ld.yaml
+++ b/quote/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/quote/src/test/resources/application-scorpio.yaml
+++ b/quote/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count

--- a/resource-catalog/src/main/java/org/fiware/tmforum/resourcecatalog/rest/ResourceSpecifcationApiController.java
+++ b/resource-catalog/src/main/java/org/fiware/tmforum/resourcecatalog/rest/ResourceSpecifcationApiController.java
@@ -316,29 +316,13 @@ public class ResourceSpecifcationApiController extends AbstractApiController<Res
 	@Override
 	public Mono<HttpResponse<List<ResourceSpecificationVO>>> listResourceSpecification(@Nullable String fields,
 			@Nullable Integer offset, @Nullable Integer limit) {
-		// Polymorphic listing: query each registered NGSI-LD entity type in parallel and merge.
-		// Each branch uses its concrete domain class so sub-type fields round-trip with full fidelity.
-		List<Mono<List<ResourceSpecificationVO>>> typeQueries = new ArrayList<>();
-
-		for (Map.Entry<String, Class<? extends ResourceSpecification>> entry :
-				ResourceTypeRegistry.SPEC_ENTITY_TYPES.entrySet()) {
-			String entityType = entry.getKey();
-			Class<? extends ResourceSpecification> entityClass = entry.getValue();
-			Mono<List<ResourceSpecificationVO>> query = list(offset, limit, entityType, entityClass)
-					.map(stream -> stream.map(this::mapSpecToVO).toList())
-					.switchIfEmpty(Mono.just(List.of()));
-			typeQueries.add(query);
-		}
-
-		return Mono.zip(typeQueries, results -> {
-			List<ResourceSpecificationVO> combined = new ArrayList<>();
-			for (Object result : results) {
-				@SuppressWarnings("unchecked")
-				List<ResourceSpecificationVO> typed = (List<ResourceSpecificationVO>) result;
-				combined.addAll(typed);
-			}
-			return combined;
-		}).map(HttpResponse::ok);
+		// Polymorphic listing: query all registered NGSI-LD entity types in a single broker call so
+		// offset/limit/count are correct against the combined result set, then dispatch each returned
+		// entity to its own concrete domain class so sub-type fields round-trip with full fidelity.
+		return listPolymorphic(offset, limit, ResourceTypeRegistry.ALL_SPEC_TYPES,
+				ResourceSpecification.class, ResourceTypeRegistry::getSpecClass)
+				.map(stream -> stream.map(this::mapSpecToVO).toList())
+				.map(HttpResponse::ok);
 	}
 
 	@Override

--- a/resource-catalog/src/main/resources/application-orion-ld.yaml
+++ b/resource-catalog/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/resource-catalog/src/main/resources/application-orion-ld.yaml
+++ b/resource-catalog/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/resource-catalog/src/main/resources/application-scorpio.yaml
+++ b/resource-catalog/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/resource-catalog/src/main/resources/application.yaml
+++ b/resource-catalog/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   resource-catalog:
     basepath: ${general.basepath:/}

--- a/resource-catalog/src/test/java/org/fiware/tmforum/resourcecatalog/ResourceSpecificationApiIT.java
+++ b/resource-catalog/src/test/java/org/fiware/tmforum/resourcecatalog/ResourceSpecificationApiIT.java
@@ -15,6 +15,7 @@ import org.fiware.tmforum.common.notification.TMForumEventHandler;
 import org.fiware.tmforum.common.test.AbstractApiIT;
 import org.fiware.tmforum.common.test.ArgumentPair;
 import org.fiware.tmforum.resource.ResourceSpecification;
+import org.fiware.tmforum.resource.ResourceTypeRegistry;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -476,6 +477,59 @@ public class ResourceSpecificationApiIT extends AbstractApiIT implements Resourc
 	}
 
 	@Test
+	public void listResourceSpecificationCombinesAllSubTypesInPaginationAndCount() throws Exception {
+		int baseTypeCount = 3;
+		int subTypeCount = 2;
+
+		for (int i = 0; i < baseTypeCount; i++) {
+			ResourceSpecificationCreateVO createVO =
+					ResourceSpecificationCreateVOTestExample.build().atSchemaLocation(null);
+			HttpResponse<ResourceSpecificationVO> response =
+					callAndCatch(() -> resourceSpecificationApiTestClient.createResourceSpecification(null, createVO));
+			assertEquals(HttpStatus.CREATED, response.getStatus(), "The base type resourceSpecification should have been created.");
+		}
+		for (int i = 0; i < subTypeCount; i++) {
+			ResourceSpecificationCreateVO createVO =
+					ResourceSpecificationCreateVOTestExample.build().atSchemaLocation(null);
+			createVO.atType("LogicalResourceSpecification");
+			HttpResponse<ResourceSpecificationVO> response =
+					callAndCatch(() -> resourceSpecificationApiTestClient.createResourceSpecification(null, createVO));
+			assertEquals(HttpStatus.CREATED, response.getStatus(), "The sub-type resourceSpecification should have been created.");
+		}
+
+		int totalCount = baseTypeCount + subTypeCount;
+
+		HttpResponse<List<ResourceSpecificationVO>> fullResponse = callAndCatch(
+				() -> resourceSpecificationApiTestClient.listResourceSpecification(null, null, null, null));
+		assertEquals(HttpStatus.OK, fullResponse.getStatus(), "The list should be accessible.");
+		assertEquals(totalCount, fullResponse.getBody().get().size(),
+				"Base type and sub-type resourceSpecifications must all be returned by the same listing call.");
+		assertEquals(String.valueOf(totalCount), fullResponse.getHeaders().get("X-Total-Count"),
+				"X-Total-Count must reflect the combined total across all sub-types, not just the base type.");
+
+		int limit = 2;
+		HttpResponse<List<ResourceSpecificationVO>> firstPage = callAndCatch(
+				() -> resourceSpecificationApiTestClient.listResourceSpecification(null, null, 0, limit));
+		assertEquals(HttpStatus.OK, firstPage.getStatus(), "The first page should be accessible.");
+		assertEquals(limit, firstPage.getBody().get().size(),
+				"A page must never contain more than the requested limit, regardless of how many sub-types exist.");
+		assertEquals(String.valueOf(totalCount), firstPage.getHeaders().get("X-Total-Count"),
+				"X-Total-Count on a partial page must still reflect the full combined total.");
+
+		HttpResponse<List<ResourceSpecificationVO>> secondPage = callAndCatch(
+				() -> resourceSpecificationApiTestClient.listResourceSpecification(null, null, limit, limit));
+		assertEquals(HttpStatus.OK, secondPage.getStatus(), "The second page should be accessible.");
+		assertEquals(totalCount - limit, secondPage.getBody().get().size(),
+				"The remaining page must contain exactly the remaining items across all sub-types.");
+
+		List<String> pagedIds = new ArrayList<>();
+		firstPage.getBody().get().forEach(vo -> pagedIds.add(vo.getId()));
+		secondPage.getBody().get().forEach(vo -> pagedIds.add(vo.getId()));
+		assertEquals(totalCount, pagedIds.stream().distinct().count(),
+				"Pages must not overlap or duplicate items across sub-types.");
+	}
+
+	@Test
 	@Override
 	public void listResourceSpecification400() throws Exception {
 		HttpResponse<List<ResourceSpecificationVO>> badRequestResponse = callAndCatch(
@@ -922,6 +976,8 @@ public class ResourceSpecificationApiIT extends AbstractApiIT implements Resourc
 
 	@Override
 	protected String getEntityType() {
-		return ResourceSpecification.TYPE_RESOURCE_SPECIFICATION;
+		// Cover every registered sub-type too, so entities created via subtype @type (e.g. through the
+		// polymorphic listing tests) are cleaned up between tests, not just plain ResourceSpecification.
+		return ResourceTypeRegistry.ALL_SPEC_TYPES;
 	}
 }

--- a/resource-catalog/src/test/java/org/fiware/tmforum/resourcecatalog/ResourceSpecificationApiIT.java
+++ b/resource-catalog/src/test/java/org/fiware/tmforum/resourcecatalog/ResourceSpecificationApiIT.java
@@ -510,7 +510,8 @@ public class ResourceSpecificationApiIT extends AbstractApiIT implements Resourc
 		int limit = 2;
 		HttpResponse<List<ResourceSpecificationVO>> firstPage = callAndCatch(
 				() -> resourceSpecificationApiTestClient.listResourceSpecification(null, null, 0, limit));
-		assertEquals(HttpStatus.OK, firstPage.getStatus(), "The first page should be accessible.");
+		assertEquals(HttpStatus.PARTIAL_CONTENT, firstPage.getStatus(),
+				"A page that doesn't contain the full result set must be reported as 206, per TMF630.");
 		assertEquals(limit, firstPage.getBody().get().size(),
 				"A page must never contain more than the requested limit, regardless of how many sub-types exist.");
 		assertEquals(String.valueOf(totalCount), firstPage.getHeaders().get("X-Total-Count"),
@@ -518,13 +519,22 @@ public class ResourceSpecificationApiIT extends AbstractApiIT implements Resourc
 
 		HttpResponse<List<ResourceSpecificationVO>> secondPage = callAndCatch(
 				() -> resourceSpecificationApiTestClient.listResourceSpecification(null, null, limit, limit));
-		assertEquals(HttpStatus.OK, secondPage.getStatus(), "The second page should be accessible.");
-		assertEquals(totalCount - limit, secondPage.getBody().get().size(),
-				"The remaining page must contain exactly the remaining items across all sub-types.");
+		assertEquals(HttpStatus.PARTIAL_CONTENT, secondPage.getStatus(),
+				"A page that doesn't contain the full result set must be reported as 206, per TMF630.");
+		assertEquals(limit, secondPage.getBody().get().size(),
+				"The second page must contain exactly `limit` items across all sub-types.");
+
+		HttpResponse<List<ResourceSpecificationVO>> thirdPage = callAndCatch(
+				() -> resourceSpecificationApiTestClient.listResourceSpecification(null, null, 2 * limit, limit));
+		assertEquals(HttpStatus.PARTIAL_CONTENT, thirdPage.getStatus(),
+				"A page that doesn't contain the full result set must be reported as 206, per TMF630.");
+		assertEquals(totalCount - 2 * limit, thirdPage.getBody().get().size(),
+				"The final page must contain exactly the remaining items across all sub-types.");
 
 		List<String> pagedIds = new ArrayList<>();
 		firstPage.getBody().get().forEach(vo -> pagedIds.add(vo.getId()));
 		secondPage.getBody().get().forEach(vo -> pagedIds.add(vo.getId()));
+		thirdPage.getBody().get().forEach(vo -> pagedIds.add(vo.getId()));
 		assertEquals(totalCount, pagedIds.stream().distinct().count(),
 				"Pages must not overlap or duplicate items across sub-types.");
 	}

--- a/resource-function-activation/src/main/resources/application-orion-ld.yaml
+++ b/resource-function-activation/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/resource-function-activation/src/main/resources/application-orion-ld.yaml
+++ b/resource-function-activation/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/resource-function-activation/src/main/resources/application-scorpio.yaml
+++ b/resource-function-activation/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/resource-function-activation/src/main/resources/application.yaml
+++ b/resource-function-activation/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 
 api:
   resource-function-activation:

--- a/resource-function-activation/src/test/resources/application-orion-ld.yaml
+++ b/resource-function-activation/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/resource-function-activation/src/test/resources/application-orion-ld.yaml
+++ b/resource-function-activation/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/resource-function-activation/src/test/resources/application-scorpio.yaml
+++ b/resource-function-activation/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count

--- a/resource-inventory/src/main/java/org/fiware/tmforum/resourceinventory/rest/ResourceApiController.java
+++ b/resource-inventory/src/main/java/org/fiware/tmforum/resourceinventory/rest/ResourceApiController.java
@@ -281,29 +281,13 @@ public class ResourceApiController extends AbstractApiController<Resource> imple
 	@Override
 	public Mono<HttpResponse<List<ResourceVO>>> listResource(@Nullable String fields, @Nullable Integer offset,
 			@Nullable Integer limit) {
-		// Polymorphic listing: query each registered NGSI-LD entity type in parallel and merge.
-		// Each branch uses its concrete domain class so sub-type fields round-trip with full fidelity.
-		List<Mono<List<ResourceVO>>> typeQueries = new ArrayList<>();
-
-		for (Map.Entry<String, Class<? extends Resource>> entry :
-				ResourceTypeRegistry.RESOURCE_ENTITY_TYPES.entrySet()) {
-			String entityType = entry.getKey();
-			Class<? extends Resource> entityClass = entry.getValue();
-			Mono<List<ResourceVO>> query = list(offset, limit, entityType, entityClass)
-					.map(stream -> stream.map(this::mapResourceToVO).toList())
-					.switchIfEmpty(Mono.just(List.of()));
-			typeQueries.add(query);
-		}
-
-		return Mono.zip(typeQueries, results -> {
-			List<ResourceVO> combined = new ArrayList<>();
-			for (Object result : results) {
-				@SuppressWarnings("unchecked")
-				List<ResourceVO> typed = (List<ResourceVO>) result;
-				combined.addAll(typed);
-			}
-			return combined;
-		}).map(HttpResponse::ok);
+		// Polymorphic listing: query all registered NGSI-LD entity types in a single broker call so
+		// offset/limit/count are correct against the combined result set, then dispatch each returned
+		// entity to its own concrete domain class so sub-type fields round-trip with full fidelity.
+		return listPolymorphic(offset, limit, ResourceTypeRegistry.ALL_RESOURCE_TYPES,
+				Resource.class, ResourceTypeRegistry::getResourceClass)
+				.map(stream -> stream.map(this::mapResourceToVO).toList())
+				.map(HttpResponse::ok);
 	}
 
 	@Override

--- a/resource-inventory/src/main/resources/application-orion-ld.yaml
+++ b/resource-inventory/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/resource-inventory/src/main/resources/application-orion-ld.yaml
+++ b/resource-inventory/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/resource-inventory/src/main/resources/application-scorpio.yaml
+++ b/resource-inventory/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/resource-inventory/src/main/resources/application.yaml
+++ b/resource-inventory/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 
 api:
   resource-inventory:

--- a/resource-inventory/src/test/java/org/fiware/tmforum/resourceinventory/ResourceApiIT.java
+++ b/resource-inventory/src/test/java/org/fiware/tmforum/resourceinventory/ResourceApiIT.java
@@ -15,6 +15,7 @@ import org.fiware.tmforum.common.notification.TMForumEventHandler;
 import org.fiware.tmforum.common.test.AbstractApiIT;
 import org.fiware.tmforum.common.test.ArgumentPair;
 import org.fiware.tmforum.resource.Resource;
+import org.fiware.tmforum.resource.ResourceTypeRegistry;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -993,6 +994,8 @@ public class ResourceApiIT extends AbstractApiIT implements ResourceApiTestSpec 
 
 	@Override
 	protected String getEntityType() {
-		return Resource.TYPE_RESOURCE;
+		// Cover every registered sub-type too, so entities created via subtype @type (e.g. through the
+		// polymorphic listing tests) are cleaned up between tests, not just plain Resource.
+		return ResourceTypeRegistry.ALL_RESOURCE_TYPES;
 	}
 }

--- a/resource-inventory/src/test/resources/application-orion-ld.yaml
+++ b/resource-inventory/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/resource-inventory/src/test/resources/application-orion-ld.yaml
+++ b/resource-inventory/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/resource-inventory/src/test/resources/application-scorpio.yaml
+++ b/resource-inventory/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count

--- a/resource-order-management/src/main/resources/application-orion-ld.yaml
+++ b/resource-order-management/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/resource-order-management/src/main/resources/application-orion-ld.yaml
+++ b/resource-order-management/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/resource-order-management/src/main/resources/application-scorpio.yaml
+++ b/resource-order-management/src/main/resources/application-scorpio.yaml
@@ -2,5 +2,5 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
-
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/resource-order-management/src/main/resources/application.yaml
+++ b/resource-order-management/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   resource-order-management:
     basepath: ${general.basepath:/}

--- a/service-catalog/src/main/resources/application-orion-ld.yaml
+++ b/service-catalog/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/service-catalog/src/main/resources/application-orion-ld.yaml
+++ b/service-catalog/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/service-catalog/src/main/resources/application-scorpio.yaml
+++ b/service-catalog/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/service-catalog/src/main/resources/application.yaml
+++ b/service-catalog/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   service-catalog:
     basepath: ${general.basepath:/}

--- a/service-inventory/src/main/resources/application-orion-ld.yaml
+++ b/service-inventory/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/service-inventory/src/main/resources/application-orion-ld.yaml
+++ b/service-inventory/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/service-inventory/src/main/resources/application-scorpio.yaml
+++ b/service-inventory/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/service-inventory/src/main/resources/application.yaml
+++ b/service-inventory/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 api:
   service-inventory:
     basepath: ${general.basepath:/}

--- a/service-inventory/src/test/resources/application-orion-ld.yaml
+++ b/service-inventory/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/service-inventory/src/test/resources/application-orion-ld.yaml
+++ b/service-inventory/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/service-inventory/src/test/resources/application-scorpio.yaml
+++ b/service-inventory/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count

--- a/service-order-management/src/main/resources/application-orion-ld.yaml
+++ b/service-order-management/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/service-order-management/src/main/resources/application-orion-ld.yaml
+++ b/service-order-management/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/service-order-management/src/main/resources/application-scorpio.yaml
+++ b/service-order-management/src/main/resources/application-scorpio.yaml
@@ -2,5 +2,5 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
-
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/service-order-management/src/main/resources/application.yaml
+++ b/service-order-management/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8641
+  countHeader: NGSILD-Results-Count
 api:
   service-order-management:
     basepath: ${general.basepath:/}

--- a/software-management/src/main/java/org/fiware/tmforum/softwaremanagement/rest/ResourceApiController.java
+++ b/software-management/src/main/java/org/fiware/tmforum/softwaremanagement/rest/ResourceApiController.java
@@ -359,28 +359,13 @@ public class ResourceApiController extends AbstractApiController<Resource> imple
 	@Override
 	public Mono<HttpResponse<List<ResourceVO>>> listResource(@Nullable String fields, @Nullable Integer offset,
 			@Nullable Integer limit) {
-		// Query each registered type and merge results
-		List<Mono<List<ResourceVO>>> typeQueries = new ArrayList<>();
-
-		for (Map.Entry<String, Class<? extends Resource>> entry :
-				ResourceTypeRegistry.RESOURCE_ENTITY_TYPES.entrySet()) {
-			String entityType = entry.getKey();
-			Class<? extends Resource> entityClass = entry.getValue();
-			Mono<List<ResourceVO>> query = list(offset, limit, entityType, entityClass)
-					.map(stream -> stream.map(this::mapResourceToVO).toList())
-					.switchIfEmpty(Mono.just(List.of()));
-			typeQueries.add(query);
-		}
-
-		return Mono.zip(typeQueries, results -> {
-			List<ResourceVO> combined = new ArrayList<>();
-			for (Object result : results) {
-				@SuppressWarnings("unchecked")
-				List<ResourceVO> typed = (List<ResourceVO>) result;
-				combined.addAll(typed);
-			}
-			return combined;
-		}).map(HttpResponse::ok);
+		// Polymorphic listing: query all registered NGSI-LD entity types in a single broker call so
+		// offset/limit/count are correct against the combined result set, then dispatch each returned
+		// entity to its own concrete domain class so sub-type fields round-trip with full fidelity.
+		return listPolymorphic(offset, limit, ResourceTypeRegistry.ALL_RESOURCE_TYPES,
+				Resource.class, ResourceTypeRegistry::getResourceClass)
+				.map(stream -> stream.map(this::mapResourceToVO).toList())
+				.map(HttpResponse::ok);
 	}
 
 	/**

--- a/software-management/src/main/java/org/fiware/tmforum/softwaremanagement/rest/ResourceSpecificationApiController.java
+++ b/software-management/src/main/java/org/fiware/tmforum/softwaremanagement/rest/ResourceSpecificationApiController.java
@@ -325,27 +325,13 @@ public class ResourceSpecificationApiController extends AbstractApiController<Re
 	@Override
 	public Mono<HttpResponse<List<ResourceSpecificationVO>>> listResourceSpecification(@Nullable String fields,
 			@Nullable Integer offset, @Nullable Integer limit) {
-		List<Mono<List<ResourceSpecificationVO>>> typeQueries = new ArrayList<>();
-
-		for (Map.Entry<String, Class<? extends ResourceSpecification>> entry :
-				ResourceTypeRegistry.SPEC_ENTITY_TYPES.entrySet()) {
-			String entityType = entry.getKey();
-			Class<? extends ResourceSpecification> entityClass = entry.getValue();
-			Mono<List<ResourceSpecificationVO>> query = list(offset, limit, entityType, entityClass)
-					.map(stream -> stream.map(this::mapSpecToVO).toList())
-					.switchIfEmpty(Mono.just(List.of()));
-			typeQueries.add(query);
-		}
-
-		return Mono.zip(typeQueries, results -> {
-			List<ResourceSpecificationVO> combined = new ArrayList<>();
-			for (Object result : results) {
-				@SuppressWarnings("unchecked")
-				List<ResourceSpecificationVO> typed = (List<ResourceSpecificationVO>) result;
-				combined.addAll(typed);
-			}
-			return combined;
-		}).map(HttpResponse::ok);
+		// Polymorphic listing: query all registered NGSI-LD entity types in a single broker call so
+		// offset/limit/count are correct against the combined result set, then dispatch each returned
+		// entity to its own concrete domain class so sub-type fields round-trip with full fidelity.
+		return listPolymorphic(offset, limit, ResourceTypeRegistry.ALL_SPEC_TYPES,
+				ResourceSpecification.class, ResourceTypeRegistry::getSpecClass)
+				.map(stream -> stream.map(this::mapSpecToVO).toList())
+				.map(HttpResponse::ok);
 	}
 
 	/**

--- a/software-management/src/main/resources/application-orion-ld.yaml
+++ b/software-management/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/software-management/src/main/resources/application-orion-ld.yaml
+++ b/software-management/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/software-management/src/main/resources/application-scorpio.yaml
+++ b/software-management/src/main/resources/application-scorpio.yaml
@@ -2,5 +2,5 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
-
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/software-management/src/main/resources/application.yaml
+++ b/software-management/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 
 api:
   software-management:

--- a/usage-management/src/main/resources/application-orion-ld.yaml
+++ b/usage-management/src/main/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/usage-management/src/main/resources/application-orion-ld.yaml
+++ b/usage-management/src/main/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/usage-management/src/main/resources/application-scorpio.yaml
+++ b/usage-management/src/main/resources/application-scorpio.yaml
@@ -3,3 +3,4 @@ general:
   ngsildOrQueryKey: ","
   encloseQuery: false
   replaceOnUpdate: true
+  countHeader: NGSILD-Results-Count

--- a/usage-management/src/main/resources/application.yaml
+++ b/usage-management/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ loggers:
 general:
   contextUrl: https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld
   serverHost: http://localhost:8632
+  countHeader: NGSILD-Results-Count
 
 api:
   usage-management:

--- a/usage-management/src/test/resources/application-orion-ld.yaml
+++ b/usage-management/src/test/resources/application-orion-ld.yaml
@@ -2,4 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
-  countHeader: Fiware-Total-Count
+  countHeader: NGSILD-Results-Count

--- a/usage-management/src/test/resources/application-orion-ld.yaml
+++ b/usage-management/src/test/resources/application-orion-ld.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ";"
   ngsildOrQueryKey: ";"
   encloseQuery: true
+  countHeader: Fiware-Total-Count

--- a/usage-management/src/test/resources/application-scorpio.yaml
+++ b/usage-management/src/test/resources/application-scorpio.yaml
@@ -2,3 +2,4 @@ general:
   ngsildOrQueryValue: ","
   ngsildOrQueryKey: ","
   encloseQuery: false
+  countHeader: NGSILD-Results-Count


### PR DESCRIPTION
- Add RFC 8288 Link headers (self/first/prev/next) and X-Forwarded-* aware URL building for paginated list responses.
- Report X-Total-Count and return 206 Partial Content when a page doesn't cover the full result set, backed by the broker's NGSI-LD count query param.
- Fix X-Total-Count/pagination on polymorphic listings (resourceSpecification, resource in resource-catalog/resource-inventory/software-management): these used to fan out one query per NGSI-LD sub-type and merge results client-side, which corrupted the count and offset/limit semantics. Now queried in a single broker call.
- Default general.countHeader to NGSILD-Results-Count, the standard NGSI-LD header (Orion-LD still overrides it to Fiware-Total-Count per profile).
- Translate the TMForum `sort` query param (`sort=name,-billDate`) into NGSI-LD's `orderBy` syntax (`orderBy=name,billDate;desc`).