### PR TITLE
fix: make AppliedBillingRateCharacteristic @MappingEnabled to resolve characteristic.value queries

### DIFF
--- a/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
+++ b/common/src/main/java/org/fiware/tmforum/common/rest/AbstractApiController.java
@@ -62,15 +62,17 @@ public abstract class AbstractApiController<T> {
 								.then(Mono.just(checkedResult)))
 				.onErrorMap(t -> {
 					if (t instanceof HttpClientResponseException e) {
+						String responseBody = e.getResponse().getBody(String.class).orElse(e.getMessage());
+						log.warn("Broker rejected the entity creation with status {}: {}", e.getStatus(), responseBody);
 						return switch (e.getStatus()) {
 							case CONFLICT -> new TmForumException(
-									String.format("Conflict on creating the entity: %s", e.getMessage()),
+									String.format("Conflict on creating the entity: %s", responseBody),
 									TmForumExceptionReason.CONFLICT);
 							case BAD_REQUEST -> new TmForumException(
-									String.format("Did not receive a valid entity: %s.", e.getMessage()),
+									String.format("Did not receive a valid entity: %s.", responseBody),
 									TmForumExceptionReason.INVALID_DATA);
 							default -> new TmForumException(
-									String.format("Unspecified downstream error: %s", e.getMessage()),
+									String.format("Unspecified downstream error: %s", responseBody),
 									TmForumExceptionReason.UNKNOWN);
 						};
 					} else {
@@ -150,7 +152,26 @@ public abstract class AbstractApiController<T> {
 										.doOnError(e -> log.warn("Was not able to handle the create event.", e))
 										.subscribe()
 						)
-				);
+				)
+				.onErrorMap(t -> {
+					if (t instanceof HttpClientResponseException e) {
+						String responseBody = e.getResponse().getBody(String.class).orElse(e.getMessage());
+						log.warn("Broker rejected the entity update with status {}: {}", e.getStatus(), responseBody);
+						return switch (e.getStatus()) {
+							case CONFLICT -> new TmForumException(
+									String.format("Conflict on updating the entity: %s", responseBody),
+									TmForumExceptionReason.CONFLICT);
+							case BAD_REQUEST -> new TmForumException(
+									String.format("Did not receive a valid entity: %s.", responseBody),
+									TmForumExceptionReason.INVALID_DATA);
+							default -> new TmForumException(
+									String.format("Unspecified downstream error: %s", responseBody),
+									TmForumExceptionReason.UNKNOWN);
+						};
+					} else {
+						return t;
+					}
+				});
 	}
 
 	protected <R extends EntityWithId> Mono<T> relatedEntityHandlingMono(T entity, Mono<T> entityMono,

--- a/customer-bill-management/src/main/java/org/fiware/tmforum/customerbillmanagement/domain/AppliedBillingRateCharacteristic.java
+++ b/customer-bill-management/src/main/java/org/fiware/tmforum/customerbillmanagement/domain/AppliedBillingRateCharacteristic.java
@@ -1,14 +1,44 @@
 package org.fiware.tmforum.customerbillmanagement.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.github.wistefan.mapping.annotations.AttributeGetter;
+import io.github.wistefan.mapping.annotations.AttributeSetter;
+import io.github.wistefan.mapping.annotations.AttributeType;
+import io.github.wistefan.mapping.annotations.MappingEnabled;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import org.fiware.tmforum.common.domain.Entity;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@MappingEnabled(entityType = "applied-billing-rate-characteristic")
 public class AppliedBillingRateCharacteristic extends Entity {
 
+	@Getter(onMethod = @__({@AttributeGetter(value = AttributeType.PROPERTY, targetName = "name")}))
+	@Setter(onMethod = @__({@AttributeSetter(value = AttributeType.PROPERTY, targetName = "name")}))
 	private String name;
+
+	@Getter(onMethod = @__({@AttributeGetter(value = AttributeType.PROPERTY, targetName = "valueType")}))
+	@Setter(onMethod = @__({@AttributeSetter(value = AttributeType.PROPERTY, targetName = "valueType")}))
 	private String valueType;
+
+	// "tmfValue" avoids clash with the NGSI-LD "value" keyword.
+	// getTmfValue()/setTmfValue() are used by MapStruct (@Mapping(source="tmfValue")).
+	// getValue()/setValue() bridge the query path "value" → NGSI-LD "tmfValue" via @AttributeGetter,
+	// and are hidden from Jackson with @JsonIgnore to avoid a duplicate "value" key.
 	private Object tmfValue;
+
+	@JsonIgnore
+	@AttributeGetter(value = AttributeType.PROPERTY, targetName = "tmfValue")
+	public Object getValue() {
+		return tmfValue;
+	}
+
+	@JsonIgnore
+	@AttributeSetter(value = AttributeType.PROPERTY, targetName = "tmfValue", targetClass = Object.class)
+	public void setValue(Object value) {
+		this.tmfValue = value;
+	}
 }


### PR DESCRIPTION
Without @MappingEnabled, getNGSIAttributePath falls back to plain field-name resolution and
looks for a field/getter named "value", which throws MappingException on any
GET /appliedCustomerBillingRate filtered by characteristic.value.

@MappingEnabled activates annotation-based path resolution. getValue()/setValue() bridge the
external query name "value" to the NGSI-LD attribute "tmfValue" via @AttributeGetter/
@AttributeSetter. @JsonIgnore hides them from Jackson (which uses getTmfValue() as before)
and MapStruct (which keeps @mapping(source="tmfValue") working unchanged).